### PR TITLE
[buildkite] redacted vars #2

### DIFF
--- a/.buildkite/scheduler.yml
+++ b/.buildkite/scheduler.yml
@@ -32,6 +32,7 @@ steps:
           label: ":rocket: Trigger: Fetch Solana snapshot ($$max_available_epoch)"
           async: false
           build:
+            branch: $$BUILDKITE_BRANCH
             env:
               EPOCH: $$max_available_epoch
       EOF

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -23,7 +23,7 @@ steps:
     commands:
     - |
       epoch=${EPOCH:-$(buildkite-agent meta-data get epoch)}
-      buildkite-agent meta-data set epoch "$$epoch"
+      buildkite-agent meta-data set --redacted-vars="" epoch "$$epoch"
       curl "$$DISCORD_WEBHOOK_VALIDATOR_BONDS" -H "Content-Type: application/json" -d '{
         "embeds": [
           {


### PR DESCRIPTION
That stuff makes epoch 761 be 76. Crappy thing this stuff.


```
2025-03-26 14:35:34 WARN   Meta-data value for key "epoch" contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret
```