### PR TITLE
[pipeline] removal jito snapshot from scheduler processing

### DIFF
--- a/.buildkite/scheduler.yml
+++ b/.buildkite/scheduler.yml
@@ -23,7 +23,7 @@ steps:
     - |
       max_processed_epoch=$(gcloud storage ls "gs://marinade-solana-snapshot-mainnet/**/*.json" | awk -F / '{print $$4}' | sort -nr | head -n 1)
       max_processed_epoch="$${max_processed_epoch%%[^0-9]*}"
-      max_available_epoch=$(gcloud storage ls "gs://jito-mainnet/**/*.tar.zst" "gs://marinade-solana-snapshot-mainnet/**/*.tar.zst" | awk -F / '{print $$4}' | sort -nr | head -n 1)
+      max_available_epoch=$(gcloud storage ls "gs://marinade-solana-snapshot-mainnet/**/*.tar.zst" | awk -F / '{print $$4}' | sort -nr | head -n 1)
       echo max_processed_epoch: $$max_processed_epoch
       echo max_available_epoch: $$max_available_epoch
       (( $$max_processed_epoch < $$max_available_epoch )) && cat <<EOF | buildkite-agent pipeline upload


### PR DESCRIPTION
Let's not use jito as a snapshot source
See https://marinade-group.slack.com/archives/C08131GDTB7/p1750231497942959