### PR TITLE
[GEN-8624][parser] parsing jito tips + fixes in stake processing

### DIFF
--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -131,6 +131,7 @@ steps:
     artifact_paths:
         - ./validators.json
         - ./stakes.json
+        - ./jito-stake-meta.json
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -139,10 +140,16 @@ steps:
       ./target/release/snapshot-parser-validator-cli \
         --ledger-path "$$snapshot_dir" \
         --output-validator-meta-collection "./validators.json" \
-        --output-stake-meta-collection "./stakes.json"
+        --output-stake-meta-collection "./stakes.json" \
+        --output-jito-stake-meta "./jito-stake-meta.json"
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
+      if [[ -f ./jito-stake-meta.json ]]; then
+        cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
+      else
+        echo "Jito stake meta collection was not produced!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
+      fi
 
   - wait: ~
 
@@ -161,6 +168,12 @@ steps:
     - epoch=$(buildkite-agent meta-data get epoch)
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+    - |
+      if [[ -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
+        gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+      else
+        echo "Jito stake meta collection was not produced!"
+      fi
 
   - wait: ~
 

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,6 @@
 large-error-threshold = 1000
+
+disallowed-methods = [
+    { path = "solana_stake_interface::state::Delegation::stake_activating_and_deactivating", reason = "use snapshot_parser::stake_activation::StakeActivation, which sources the warmup/cooldown rate from the bank" },
+    { path = "solana_stake_interface::state::Delegation::stake", reason = "use snapshot_parser::stake_activation::StakeActivation, which sources the warmup/cooldown rate from the bank" },
+]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Cargo Lint
+name: Cargo lint and test
 permissions:
   contents: read
 
@@ -18,12 +18,20 @@ env:
   RUSTFLAGS: -C strip=symbols -C opt-level=s
 
 jobs:
-  cargo-lint:
+  lint-and-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 50
     steps:
-      - name: 🚧 Checkout project
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - name: 🛀🏼 Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
+      - name: 🏃‍♂️‍➡️ Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Install rust compilation dependencies
         run: |
@@ -34,12 +42,18 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: 1.94.1
+          components: rustfmt, clippy
 
-      - name: Cache Rust dependencies
+      - name: 🧠 Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: lint-and-test
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      - name: 🧭 Run cargo lint & clippy
-        run: cargo fmt -- --check && cargo clippy -- -D warnings
+      - name: 🧭 Run lint
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: 🧨 Run test
+        run: cargo test --workspace --all-features

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: 🏃‍♂️‍➡️ Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # cargo build scripts and proc macros run PR code and could read a persisted git token
+          persist-credentials: false
 
       - name: ⚙️ Install rust compilation dependencies
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5311,10 +5311,12 @@ version = "0.0.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
+ "bincode",
  "clap",
  "env_logger",
  "log",
  "serde",
+ "serde_json",
  "snapshot-parser",
  "solana-accounts-db",
  "solana-program 4.0.0",
@@ -5366,6 +5368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385cad928d576683db3afef1b88d00a31a7126cc9f6f3f0c9f6b2d181437f53c"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5476,6 +5479,7 @@ dependencies = [
  "memmap2 0.9.11",
  "modular-bitfield",
  "num_cpus",
+ "qualifier_attr",
  "rand 0.9.4",
  "rayon",
  "seqlock",
@@ -5488,6 +5492,7 @@ dependencies = [
  "solana-epoch-schedule 3.2.0",
  "solana-fee-calculator 3.2.2",
  "solana-hash 4.4.0",
+ "solana-keypair",
  "solana-lattice-hash",
  "solana-measure",
  "solana-message 4.1.1",
@@ -5495,8 +5500,11 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
+ "solana-rent 4.3.0",
  "solana-reward-info",
+ "solana-signer",
  "solana-slot-hashes 3.1.0",
+ "solana-stake-interface 3.1.0",
  "solana-svm-transaction",
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
@@ -5504,6 +5512,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error 3.2.1",
+ "solana-vote-program",
  "spl-generic-token",
  "tempfile",
  "thiserror 2.0.18",
@@ -7264,6 +7273,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program-binaries"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64af933042aa6e1a10d011c23db472921cdb549379da7197122b353f5c477c90"
+dependencies = [
+ "bincode",
+ "solana-account 4.3.1",
+ "solana-loader-v3-interface 7.0.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.3.0",
+ "solana-sdk-ids 3.1.0",
+ "spl-generic-token",
+]
+
+[[package]]
 name = "solana-program-entrypoint"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7386,6 +7410,7 @@ dependencies = [
  "solana-instruction 3.4.0",
  "solana-last-restart-slot 3.1.0",
  "solana-loader-v3-interface 7.0.0",
+ "solana-message 4.1.1",
  "solana-program-entrypoint 3.1.1",
  "solana-pubkey 4.2.0",
  "solana-rent 4.3.0",
@@ -7683,6 +7708,7 @@ dependencies = [
  "solana-perf",
  "solana-poh-config",
  "solana-precompile-error",
+ "solana-program-binaries",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
@@ -8318,6 +8344,7 @@ dependencies = [
  "ahash 0.8.12",
  "log",
  "percentage",
+ "qualifier_attr",
  "serde",
  "solana-account 4.3.1",
  "solana-clock 3.1.1",
@@ -8856,10 +8883,14 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3e5e4c2393e1352d7701d727c9d4d7ffb2f03e7bff2bed6906870297261b1a"
 dependencies = [
+ "bincode",
  "log",
+ "qualifier_attr",
+ "rand 0.9.4",
  "serde",
  "solana-account 4.3.1",
  "solana-bincode 3.1.0",
+ "solana-bls-signatures",
  "solana-clock 3.1.1",
  "solana-hash 4.4.0",
  "solana-instruction 3.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "snapshot-parser-validator-cli",
     "snapshot-parser-tokens-cli",
 ]
-resolver = "1"
+resolver = "2"
 
 
 [profile.release]

--- a/snapshot-parser-validator-cli/Cargo.toml
+++ b/snapshot-parser-validator-cli/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
+bincode = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
@@ -20,3 +21,6 @@ solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-interface = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -1,7 +1,7 @@
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 use snapshot_parser::stake_meta;
-use snapshot_parser::utils::{write_to_json_file, write_to_json_file_compact};
+use snapshot_parser::utils::write_to_json_file;
 use snapshot_parser_validator_cli::scanned_accounts::scan_required_accounts;
 use snapshot_parser_validator_cli::{jito_stake_meta, validator_meta};
 use std::thread::spawn;
@@ -113,8 +113,8 @@ fn main() -> anyhow::Result<()> {
                         &tip_distribution,
                         &priority_fee_distribution,
                     )?;
-                // Jito publishes the collection compacted; the document is too big to be held as a String
-                write_to_json_file_compact(&jito_stake_meta_collection, &output_path)?;
+                // Jito publishes this collection pretty-printed; parity is checked byte for byte
+                write_to_json_file(&jito_stake_meta_collection, &output_path)?;
                 info!("Jito stake meta collection finished.");
                 Ok(())
             };

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -1,12 +1,16 @@
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 use snapshot_parser::stake_meta;
-use snapshot_parser::utils::write_to_json_file;
-use snapshot_parser_validator_cli::validator_meta;
+use snapshot_parser::utils::{write_to_json_file, write_to_json_file_compact};
+use snapshot_parser_validator_cli::scanned_accounts::scan_required_accounts;
+use snapshot_parser_validator_cli::{jito_stake_meta, validator_meta};
 use std::thread::spawn;
 use {
-    clap::Parser, log::info, snapshot_parser::bank_loader::create_bank_from_ledger,
-    snapshot_parser::cli::path_parser, std::path::PathBuf,
+    clap::Parser,
+    log::{error, info},
+    snapshot_parser::bank_loader::create_bank_from_ledger,
+    snapshot_parser::cli::path_parser,
+    std::path::PathBuf,
 };
 
 #[derive(Parser, Debug)]
@@ -23,6 +27,14 @@ struct Args {
     /// Path to write JSON file to for the stake metas (e.g., stakes.json)
     #[arg(long, env)]
     output_stake_meta_collection: String,
+
+    /// Path to write JSON file to for the Jito-format stake metas (e.g., jito-stake-meta.json)
+    #[arg(long, env)]
+    output_jito_stake_meta: Option<String>,
+
+    /// Cross-check the single-pass account scan against get_program_accounts; costs a scan per owner
+    #[arg(long, env, default_value_t = false)]
+    verify_account_scan: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -36,14 +48,22 @@ fn main() -> anyhow::Result<()> {
     info!("Creating bank from ledger path: {:?}", args.ledger_path);
     let bank = create_bank_from_ledger(&args.ledger_path)?;
 
+    info!("Scanning accounts from the bank...");
+    let scanned_accounts = scan_required_accounts(&bank, args.verify_account_scan)?;
+
     let validator_meta_collection_handle = {
         let bank = bank.clone();
+        let tip_distribution = scanned_accounts.tip_distribution.clone();
+        let priority_fee_distribution = scanned_accounts.priority_fee_distribution.clone();
         spawn(move || {
             info!("Creating validator meta collection...");
 
             let call = || -> anyhow::Result<()> {
-                let validator_meta_collection =
-                    validator_meta::generate_validator_collection(&bank)?;
+                let validator_meta_collection = validator_meta::generate_validator_collection(
+                    &bank,
+                    &tip_distribution,
+                    &priority_fee_distribution,
+                )?;
                 write_to_json_file(
                     &validator_meta_collection,
                     &args.output_validator_meta_collection,
@@ -58,11 +78,16 @@ fn main() -> anyhow::Result<()> {
 
     let stake_meta_collection_handle = {
         let bank = bank.clone();
+        let stake_accounts = scanned_accounts.stake.clone();
         spawn(move || {
             info!("Creating stake meta collection...");
 
             let call = || -> anyhow::Result<()> {
-                let stake_meta_collection = stake_meta::generate_stake_meta_collection(&bank)?;
+                let stake_meta_collection =
+                    stake_meta::generate_stake_meta_collection_for_accounts(
+                        &bank,
+                        &stake_accounts,
+                    )?;
                 write_to_json_file(&stake_meta_collection, &args.output_stake_meta_collection)?;
                 info!("Stake meta collection finished.");
                 Ok(())
@@ -72,15 +97,61 @@ fn main() -> anyhow::Result<()> {
         })
     };
 
+    let jito_stake_meta_collection_handle = args.output_jito_stake_meta.map(|output_path| {
+        let bank = bank.clone();
+        let stake_accounts = scanned_accounts.stake.clone();
+        let tip_distribution = scanned_accounts.tip_distribution.clone();
+        let priority_fee_distribution = scanned_accounts.priority_fee_distribution.clone();
+        spawn(move || {
+            info!("Creating Jito stake meta collection...");
+
+            let call = || -> anyhow::Result<()> {
+                let jito_stake_meta_collection =
+                    jito_stake_meta::generate_jito_stake_meta_collection(
+                        &bank,
+                        &stake_accounts,
+                        &tip_distribution,
+                        &priority_fee_distribution,
+                    )?;
+                // Jito publishes the collection compacted; the document is too big to be held as a String
+                write_to_json_file_compact(&jito_stake_meta_collection, &output_path)?;
+                info!("Jito stake meta collection finished.");
+                Ok(())
+            };
+
+            call()
+        })
+    });
+
+    // Every handle must be joined before returning, otherwise process exit kills a thread mid-write
+    let mut failure = None;
     for handle in [
         validator_meta_collection_handle,
         stake_meta_collection_handle,
     ] {
+        let outcome = match handle.join() {
+            Ok(Ok(())) => {
+                info!("Thread completed successfully.");
+                continue;
+            }
+            Ok(Err(err)) => format!("Error in thread: {err:?}"),
+            Err(err) => format!("Thread panicked: {err:?}"),
+        };
+        error!("{outcome}");
+        failure = failure.or(Some(outcome));
+    }
+
+    // The Jito collection is a backup of what Jito publishes itself, it must not fail the parsing
+    if let Some(handle) = jito_stake_meta_collection_handle {
         match handle.join() {
-            Ok(Ok(())) => info!("Thread completed successfully."),
-            Ok(Err(err)) => anyhow::bail!("Error in thread: {err:?}"),
-            Err(err) => anyhow::bail!("Thread panicked: {err:?}"),
+            Ok(Ok(())) => info!("Jito stake meta collection completed successfully."),
+            Ok(Err(err)) => error!("Error in Jito stake meta thread: {err:?}"),
+            Err(err) => error!("Jito stake meta thread panicked: {err:?}"),
         }
+    }
+
+    if let Some(failure) = failure {
+        anyhow::bail!(failure);
     }
 
     info!("Finished.");

--- a/snapshot-parser-validator-cli/src/jito_mev.rs
+++ b/snapshot-parser-validator-cli/src/jito_mev.rs
@@ -2,11 +2,8 @@ use crate::utils::jito_parser::{
     get_epoch_created_at, read_jito_commission_and_epoch, JitoCommissionMeta,
 };
 use solana_program::pubkey::Pubkey;
-use solana_sdk::account::Account;
-use {
-    log::info, solana_runtime::bank::Bank, solana_stake_interface::stake_history::Epoch,
-    std::sync::Arc,
-};
+use solana_sdk::account::{AccountSharedData, ReadableAccount};
+use {log::info, solana_stake_interface::stake_history::Epoch};
 
 pub struct JitoMevMeta {
     pub vote_account: Pubkey,
@@ -16,24 +13,22 @@ pub struct JitoMevMeta {
 // https://github.com/jito-foundation/jito-programs/blob/v0.1.5/mev-programs/programs/tip-distribution/src/state.rs#L32
 // only one TipDistribution account per epoch
 // https://github.com/jito-foundation/jito-programs/blob/v0.1.5/mev-programs/programs/tip-distribution/src/lib.rs#L385
-const JITO_PROGRAM: &str = "4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7";
-const TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR: [u8; 8] = [85, 64, 113, 198, 234, 94, 120, 123];
+pub(crate) const JITO_PROGRAM: &str = "4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7";
+pub(crate) const TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR: [u8; 8] =
+    [85, 64, 113, 198, 234, 94, 120, 123];
 
-pub fn fetch_jito_mev_metas(bank: &Arc<Bank>, epoch: Epoch) -> anyhow::Result<Vec<JitoMevMeta>> {
-    let jito_program: Pubkey = JITO_PROGRAM.try_into()?;
-    let jito_accounts_raw = bank.get_program_accounts(&jito_program)?;
-    info!(
-        "jito mev distribution program {} `raw` processors loaded: {}",
-        JITO_PROGRAM,
-        jito_accounts_raw.len()
-    );
-
+pub fn fetch_jito_mev_metas(
+    tip_distribution_accounts: &[(Pubkey, AccountSharedData)],
+    epoch: Epoch,
+) -> anyhow::Result<Vec<JitoMevMeta>> {
     let mut jito_mev_metas: Vec<JitoMevMeta> = Vec::new();
 
-    for (pubkey, shared_account) in jito_accounts_raw {
-        let account = Account::from(shared_account);
-        if account.data[0..8] == TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR {
-            update_jito_mev_metas(&mut jito_mev_metas, &account, pubkey, epoch)?;
+    for (pubkey, account) in tip_distribution_accounts {
+        if account
+            .data()
+            .starts_with(&TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR)
+        {
+            update_jito_mev_metas(&mut jito_mev_metas, account, *pubkey, epoch)?;
         }
     }
 
@@ -53,7 +48,7 @@ pub fn fetch_jito_mev_metas(bank: &Arc<Bank>, epoch: Epoch) -> anyhow::Result<Ve
 
 fn update_jito_mev_metas(
     jito_mev_metas: &mut Vec<JitoMevMeta>,
-    account: &Account,
+    account: &impl ReadableAccount,
     pubkey: Pubkey,
     epoch: Epoch,
 ) -> anyhow::Result<()> {
@@ -66,7 +61,7 @@ fn update_jito_mev_metas(
 
 fn update_mev_commission(
     jito_mev_metas: &mut Vec<JitoMevMeta>,
-    account: &Account,
+    account: &impl ReadableAccount,
     account_pubkey: Pubkey,
     epoch_byte_index: usize,
     epoch: Epoch,

--- a/snapshot-parser-validator-cli/src/jito_priority_fee.rs
+++ b/snapshot-parser-validator-cli/src/jito_priority_fee.rs
@@ -1,11 +1,8 @@
 use crate::utils::jito_parser::{get_epoch_created_at, read_jito_commission_and_epoch};
 use crate::utils::SliceAt;
 use solana_program::pubkey::Pubkey;
-use solana_sdk::account::Account;
-use {
-    log::info, solana_runtime::bank::Bank, solana_stake_interface::stake_history::Epoch,
-    std::sync::Arc,
-};
+use solana_sdk::account::{AccountSharedData, ReadableAccount};
+use {log::info, solana_stake_interface::stake_history::Epoch};
 
 pub struct JitoPriorityFeeMeta {
     pub validator_vote_account: Pubkey,
@@ -19,29 +16,24 @@ pub struct JitoPriorityFeeMeta {
 // A new account is created for each epoch for every validator.
 // * https://www.jito.network/blog/tiprouter-upgrade-facilitating-priority-fees/
 // * https://www.notion.so/marinade/Account-for-Jito-Tip-Distribution-Collect-1-4-22ae465715a480daa33ae55d5b92ba52
-const JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM: &str = "Priority6weCZ5HwDn29NxLFpb7TDp2iLZ6XKc5e8d3";
-const PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR: [u8; 8] =
+pub(crate) const JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM: &str =
+    "Priority6weCZ5HwDn29NxLFpb7TDp2iLZ6XKc5e8d3";
+pub(crate) const PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR: [u8; 8] =
     [163, 183, 254, 12, 121, 137, 235, 27];
 const TOTAL_LAMPORTS_TRASFERRED_BYTE_OFFSET: usize = 8 + 2 + 8; // epoch + commission + expires_at
 
 pub fn fetch_jito_priority_fee_metas(
-    bank: &Arc<Bank>,
+    priority_fee_distribution_accounts: &[(Pubkey, AccountSharedData)],
     epoch: Epoch,
 ) -> anyhow::Result<Vec<JitoPriorityFeeMeta>> {
-    let jito_program: Pubkey = JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?;
-    let jito_accounts_raw = bank.get_program_accounts(&jito_program)?;
-    info!(
-        "jito priority fee distribution program {} `raw` processors loaded: {}",
-        JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM,
-        jito_accounts_raw.len()
-    );
-
     let mut jito_priority_fee_metas: Vec<JitoPriorityFeeMeta> = Vec::new();
 
-    for (pubkey, shared_account) in jito_accounts_raw {
-        let account = Account::from(shared_account);
-        if account.data[0..8] == PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR {
-            update_jito_priority_fee_metas(&mut jito_priority_fee_metas, &account, pubkey, epoch)?;
+    for (pubkey, account) in priority_fee_distribution_accounts {
+        if account
+            .data()
+            .starts_with(&PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR)
+        {
+            update_jito_priority_fee_metas(&mut jito_priority_fee_metas, account, *pubkey, epoch)?;
         }
     }
 
@@ -61,7 +53,7 @@ pub fn fetch_jito_priority_fee_metas(
 
 fn update_jito_priority_fee_metas(
     jito_priority_fee_metas: &mut Vec<JitoPriorityFeeMeta>,
-    account: &Account,
+    account: &impl ReadableAccount,
     pubkey: Pubkey,
     epoch: Epoch,
 ) -> anyhow::Result<()> {
@@ -82,14 +74,14 @@ fn update_jito_priority_fee_metas(
 
 fn read_priority_fee_total_lamports_transferred(
     account_pubkey: Pubkey,
-    account: &Account,
+    account: &impl ReadableAccount,
     end_merkle_root_byte_index: usize, // a byte index directly after MerkleRoot struct
 ) -> anyhow::Result<u64> {
     let total_lamports_transferred_byte_index =
         end_merkle_root_byte_index + TOTAL_LAMPORTS_TRASFERRED_BYTE_OFFSET;
     let total_lamports_transferred = u64::from_le_bytes(
         account
-            .data
+            .data()
             .slice_at(total_lamports_transferred_byte_index, 8)?
             .try_into()
             .map_err(|e| {

--- a/snapshot-parser-validator-cli/src/jito_stake_meta.rs
+++ b/snapshot-parser-validator-cli/src/jito_stake_meta.rs
@@ -1,0 +1,591 @@
+use crate::jito_mev::{JITO_PROGRAM, TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR};
+use crate::jito_priority_fee::{
+    JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM, PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR,
+};
+use crate::utils::jito_parser::{
+    get_epoch_created_at, read_jito_commission_and_epoch, read_merkle_root_upload_authority,
+};
+use crate::utils::SliceAt;
+use {
+    log::{error, info, warn},
+    serde::{Deserialize, Serialize},
+    snapshot_parser::serde_serialize::pubkey_string_conversion,
+    snapshot_parser::stake_activation::StakeActivation,
+    solana_program::pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+    solana_sdk::account::{AccountSharedData, ReadableAccount},
+    solana_stake_interface::{stake_history::Epoch, state::StakeStateV2},
+    std::{collections::HashMap, sync::Arc},
+};
+
+// Replicates jito-tip-router/tip-router-operator-cli/src/stake_meta_generator.rs
+
+const JITO_TIP_PAYMENT_PROGRAM: &str = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt";
+const CONFIG_ACCOUNT_SEED: &[u8] = b"CONFIG_ACCOUNT";
+const TIP_ACCOUNT_SEEDS: [&[u8]; 8] = [
+    b"TIP_ACCOUNT_0",
+    b"TIP_ACCOUNT_1",
+    b"TIP_ACCOUNT_2",
+    b"TIP_ACCOUNT_3",
+    b"TIP_ACCOUNT_4",
+    b"TIP_ACCOUNT_5",
+    b"TIP_ACCOUNT_6",
+    b"TIP_ACCOUNT_7",
+];
+const CONFIG_TIP_RECEIVER_BYTE_INDEX: usize = 8; // anchor header
+const CONFIG_BLOCK_BUILDER_COMMISSION_PCT_BYTE_INDEX: usize = 8 + // anchor header
+    64; // tip_receiver + block_builder pubkeys
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct JitoStakeMetaCollection {
+    pub stake_metas: Vec<JitoStakeMeta>,
+    #[serde(with = "pubkey_string_conversion")]
+    pub tip_distribution_program_id: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub priority_fee_distribution_program_id: Pubkey,
+    pub bank_hash: String,
+    pub epoch: Epoch,
+    pub slot: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct JitoStakeMeta {
+    #[serde(with = "pubkey_string_conversion")]
+    pub validator_vote_account: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub validator_node_pubkey: Pubkey,
+    pub maybe_tip_distribution_meta: Option<JitoTipDistributionMeta>,
+    pub maybe_priority_fee_distribution_meta: Option<JitoPriorityFeeDistributionMeta>,
+    pub delegations: Vec<JitoDelegation>,
+    pub total_delegated: u64,
+    pub commission: u8,
+}
+
+impl Ord for JitoStakeMeta {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.validator_vote_account
+            .cmp(&other.validator_vote_account)
+    }
+}
+
+impl PartialOrd<Self> for JitoStakeMeta {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct JitoTipDistributionMeta {
+    #[serde(with = "pubkey_string_conversion")]
+    pub merkle_root_upload_authority: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub tip_distribution_pubkey: Pubkey,
+    pub total_tips: u64,
+    pub validator_fee_bps: u16,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct JitoPriorityFeeDistributionMeta {
+    #[serde(with = "pubkey_string_conversion")]
+    pub merkle_root_upload_authority: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub priority_fee_distribution_pubkey: Pubkey,
+    pub total_tips: u64,
+    pub validator_fee_bps: u16,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct JitoDelegation {
+    #[serde(with = "pubkey_string_conversion")]
+    pub stake_account_pubkey: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub staker_pubkey: Pubkey,
+    #[serde(with = "pubkey_string_conversion")]
+    pub withdrawer_pubkey: Pubkey,
+    pub lamports_delegated: u64,
+}
+
+impl Ord for JitoDelegation {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (
+            self.stake_account_pubkey,
+            self.withdrawer_pubkey,
+            self.staker_pubkey,
+            self.lamports_delegated,
+        )
+            .cmp(&(
+                other.stake_account_pubkey,
+                other.withdrawer_pubkey,
+                other.staker_pubkey,
+                other.lamports_delegated,
+            ))
+    }
+}
+
+impl PartialOrd<Self> for JitoDelegation {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+struct DistributionAccountMeta {
+    pubkey: Pubkey,
+    merkle_root_upload_authority: Pubkey,
+    validator_fee_bps: u16,
+    lamports: u64,
+    data_len: usize,
+}
+
+pub fn generate_jito_stake_meta_collection(
+    bank: &Arc<Bank>,
+    stake_accounts: &[(Pubkey, AccountSharedData)],
+    tip_distribution_accounts: &[(Pubkey, AccountSharedData)],
+    priority_fee_distribution_accounts: &[(Pubkey, AccountSharedData)],
+) -> anyhow::Result<JitoStakeMetaCollection> {
+    assert!(bank.is_frozen());
+    let epoch = bank.epoch();
+
+    let last_slot_in_epoch = bank.epoch_schedule().get_last_slot_in_epoch(epoch);
+    if bank.slot() != last_slot_in_epoch {
+        warn!(
+            "Snapshot slot is not the last slot of the epoch, tips of the remaining slots are missing and the collection may differ from what Jito publishes [epoch={}, slot={}, last_slot_in_epoch={}]",
+            epoch,
+            bank.slot(),
+            last_slot_in_epoch
+        );
+    }
+
+    let mut delegations_by_voter = group_delegations_by_voter(bank, stake_accounts)?;
+    let tip_distribution_metas = distribution_account_metas(
+        tip_distribution_accounts,
+        &TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR,
+        epoch,
+    )?;
+    if tip_distribution_metas.is_empty() {
+        anyhow::bail!("Not expected. No Jito tip distribution accounts found for epoch {epoch}. Evaluate the snapshot data.");
+    }
+    info!(
+        "Jito tip distribution accounts for epoch {}: {}",
+        epoch,
+        tip_distribution_metas.len()
+    );
+    let priority_fee_distribution_metas = distribution_account_metas(
+        priority_fee_distribution_accounts,
+        &PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR,
+        epoch,
+    )?;
+    if priority_fee_distribution_metas.is_empty() {
+        anyhow::bail!("Not expected. No Jito priority fee distribution accounts found for epoch {epoch}. Evaluate the snapshot data.");
+    }
+    info!(
+        "Jito priority fee distribution accounts for epoch {}: {}",
+        epoch,
+        priority_fee_distribution_metas.len()
+    );
+
+    let (tip_receiver, tip_receiver_fee) = read_undistributed_tip_receiver_fee(bank)?;
+
+    let epoch_vote_accounts = bank
+        .epoch_vote_accounts(epoch)
+        .ok_or_else(|| anyhow::anyhow!("No epoch vote accounts found for epoch {epoch}"))?;
+
+    let mut voters_without_delegations = 0;
+    let mut stake_metas: Vec<JitoStakeMeta> = Vec::new();
+    for (vote_pubkey, (_stake, vote_account)) in epoch_vote_accounts.iter() {
+        let Some(mut delegations) = delegations_by_voter.remove(vote_pubkey) else {
+            voters_without_delegations += 1;
+            continue;
+        };
+        delegations.sort();
+        let total_delegated = delegations.iter().try_fold(0_u64, |sum, delegation| {
+            sum.checked_add(delegation.lamports_delegated)
+                .ok_or_else(|| anyhow::anyhow!("total_delegated overflow for vote {vote_pubkey}"))
+        })?;
+
+        let maybe_tip_distribution_meta = tip_distribution_metas
+            .get(vote_pubkey)
+            .map(|meta| {
+                anyhow::Ok(JitoTipDistributionMeta {
+                    merkle_root_upload_authority: meta.merkle_root_upload_authority,
+                    tip_distribution_pubkey: meta.pubkey,
+                    total_tips: total_tips(
+                        meta,
+                        bank.get_minimum_balance_for_rent_exemption(meta.data_len),
+                        Some((&tip_receiver, tip_receiver_fee)),
+                    )?,
+                    validator_fee_bps: meta.validator_fee_bps,
+                })
+            })
+            .transpose()?;
+        let maybe_priority_fee_distribution_meta = priority_fee_distribution_metas
+            .get(vote_pubkey)
+            .map(|meta| {
+                anyhow::Ok(JitoPriorityFeeDistributionMeta {
+                    merkle_root_upload_authority: meta.merkle_root_upload_authority,
+                    priority_fee_distribution_pubkey: meta.pubkey,
+                    total_tips: total_tips(
+                        meta,
+                        bank.get_minimum_balance_for_rent_exemption(meta.data_len),
+                        None,
+                    )?,
+                    validator_fee_bps: meta.validator_fee_bps,
+                })
+            })
+            .transpose()?;
+
+        let vote_state_view = vote_account.vote_state_view();
+        stake_metas.push(JitoStakeMeta {
+            validator_vote_account: *vote_pubkey,
+            validator_node_pubkey: *vote_state_view.node_pubkey(),
+            maybe_tip_distribution_meta,
+            maybe_priority_fee_distribution_meta,
+            delegations,
+            total_delegated,
+            commission: vote_state_view.commission(),
+        });
+    }
+    if voters_without_delegations > 0 {
+        warn!("voter_pubkey not found in delegations map for {voters_without_delegations} vote accounts");
+    }
+    if !delegations_by_voter.is_empty() {
+        warn!(
+            "Delegations of {} voters not present in epoch vote accounts were dropped",
+            delegations_by_voter.len()
+        );
+    }
+    if stake_metas.is_empty() {
+        anyhow::bail!("Not expected. No Jito stake metas collected for epoch {epoch}. Evaluate the snapshot data.");
+    }
+    // Map membership is not enough: the receiver's meta must survive the delegations filter too
+    if tip_receiver_fee > 0
+        && !stake_metas.iter().any(|stake_meta| {
+            stake_meta
+                .maybe_tip_distribution_meta
+                .as_ref()
+                .is_some_and(|meta| meta.tip_distribution_pubkey == tip_receiver)
+        })
+    {
+        anyhow::bail!("Jito tip_receiver {tip_receiver} produced no stake meta for epoch {epoch}, {tip_receiver_fee} lamports of undistributed tips would be dropped");
+    }
+
+    stake_metas.sort();
+    info!("Collected Jito stake metas: {}", stake_metas.len());
+
+    Ok(JitoStakeMetaCollection {
+        stake_metas,
+        tip_distribution_program_id: JITO_PROGRAM.try_into()?,
+        priority_fee_distribution_program_id: JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?,
+        bank_hash: bank.hash().to_string(),
+        epoch,
+        slot: bank.slot(),
+    })
+}
+
+fn total_tips(
+    meta: &DistributionAccountMeta,
+    rent_exempt_minimum: u64,
+    tip_receiver: Option<(&Pubkey, u64)>,
+) -> anyhow::Result<u64> {
+    let lamports = match tip_receiver {
+        Some((tip_receiver, tip_receiver_fee)) if meta.pubkey == *tip_receiver => meta
+            .lamports
+            .checked_add(tip_receiver_fee)
+            .ok_or_else(|| anyhow::anyhow!("tip overflow for account {}", meta.pubkey))?,
+        _ => meta.lamports,
+    };
+    lamports
+        .checked_sub(rent_exempt_minimum)
+        .ok_or_else(|| anyhow::anyhow!("total_tips underflow for account {}", meta.pubkey))
+}
+
+fn group_delegations_by_voter(
+    bank: &Arc<Bank>,
+    stake_accounts: &[(Pubkey, AccountSharedData)],
+) -> anyhow::Result<HashMap<Pubkey, Vec<JitoDelegation>>> {
+    let stake_activation = StakeActivation::new(bank)?;
+
+    let mut delegations_by_voter: HashMap<Pubkey, Vec<JitoDelegation>> = HashMap::new();
+    for (pubkey, shared_account) in stake_accounts {
+        let pubkey = *pubkey;
+        let stake_state: StakeStateV2 = match bincode::deserialize(shared_account.data()) {
+            Ok(account) => account,
+            Err(err) => {
+                error!("Error parsing stake account {}: {}", pubkey, err);
+                continue;
+            }
+        };
+        let Some(stake) = stake_state.stake() else {
+            continue;
+        };
+        if stake_activation.effective(&stake.delegation) == 0 {
+            continue;
+        }
+        let authorized = stake_state.authorized().unwrap_or_default();
+        delegations_by_voter
+            .entry(stake.delegation.voter_pubkey)
+            .or_default()
+            .push(JitoDelegation {
+                stake_account_pubkey: pubkey,
+                staker_pubkey: authorized.staker,
+                withdrawer_pubkey: authorized.withdrawer,
+                lamports_delegated: stake.delegation.stake,
+            });
+    }
+    Ok(delegations_by_voter)
+}
+
+fn distribution_account_metas(
+    accounts: &[(Pubkey, AccountSharedData)],
+    discriminator: &[u8; 8],
+    epoch: Epoch,
+) -> anyhow::Result<HashMap<Pubkey, DistributionAccountMeta>> {
+    let mut metas: HashMap<Pubkey, DistributionAccountMeta> = HashMap::new();
+    for (pubkey, account) in accounts {
+        let pubkey = *pubkey;
+        if !account.data().starts_with(discriminator) {
+            continue;
+        }
+        let (epoch_created_at, epoch_byte_index) = get_epoch_created_at(account)?;
+        if epoch_created_at != epoch {
+            continue;
+        }
+        let commission_meta = read_jito_commission_and_epoch(pubkey, account, epoch_byte_index)?;
+        metas.insert(
+            commission_meta.validator_vote_account,
+            DistributionAccountMeta {
+                pubkey,
+                merkle_root_upload_authority: read_merkle_root_upload_authority(pubkey, account)?,
+                validator_fee_bps: commission_meta.validator_commission_bps,
+                lamports: account.lamports(),
+                data_len: account.data().len(),
+            },
+        );
+    }
+    Ok(metas)
+}
+
+// Tips left in the tip payment PDAs are cranked to the configured tip receiver in the next epoch
+fn read_undistributed_tip_receiver_fee(bank: &Arc<Bank>) -> anyhow::Result<(Pubkey, u64)> {
+    let tip_payment_program: Pubkey = JITO_TIP_PAYMENT_PROGRAM.try_into()?;
+    let (config_pubkey, _) =
+        Pubkey::find_program_address(&[CONFIG_ACCOUNT_SEED], &tip_payment_program);
+    let config_account = bank.get_account(&config_pubkey).ok_or_else(|| {
+        anyhow::anyhow!("Jito tip payment config account {config_pubkey} not found")
+    })?;
+    let (tip_receiver, block_builder_commission_pct) = parse_tip_payment_config(&config_account)?;
+
+    let mut excess_tip_balances: u64 = 0;
+    for seed in TIP_ACCOUNT_SEEDS {
+        let (tip_pubkey, _) = Pubkey::find_program_address(&[seed], &tip_payment_program);
+        let tip_account = bank
+            .get_account(&tip_pubkey)
+            .ok_or_else(|| anyhow::anyhow!("Jito tip payment account {tip_pubkey} not found"))?;
+        let excess = tip_account
+            .lamports()
+            .checked_sub(bank.get_minimum_balance_for_rent_exemption(tip_account.data().len()))
+            .ok_or_else(|| anyhow::anyhow!("tip balance underflow for account {tip_pubkey}"))?;
+        excess_tip_balances = excess_tip_balances
+            .checked_add(excess)
+            .ok_or_else(|| anyhow::anyhow!("excess tip balances overflow"))?;
+    }
+
+    let tip_receiver_fee =
+        split_block_builder_fee(excess_tip_balances, block_builder_commission_pct)?;
+
+    info!(
+        "Jito undistributed tips: {} lamports, tip receiver: {}, fee after block builder cut: {}",
+        excess_tip_balances, tip_receiver, tip_receiver_fee
+    );
+    Ok((tip_receiver, tip_receiver_fee))
+}
+
+// matches math in the tip payment program
+fn split_block_builder_fee(
+    excess_tip_balances: u64,
+    block_builder_commission_pct: u64,
+) -> anyhow::Result<u64> {
+    let block_builder_tips = excess_tip_balances
+        .checked_mul(block_builder_commission_pct)
+        .ok_or_else(|| anyhow::anyhow!("block_builder_tips overflow"))?
+        / 100;
+    excess_tip_balances
+        .checked_sub(block_builder_tips)
+        .ok_or_else(|| anyhow::anyhow!("tip_receiver_fee underflow"))
+}
+
+fn parse_tip_payment_config(
+    config_account: &impl ReadableAccount,
+) -> anyhow::Result<(Pubkey, u64)> {
+    let tip_receiver: Pubkey = config_account
+        .data()
+        .slice_at(CONFIG_TIP_RECEIVER_BYTE_INDEX, 32)?
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("Failed to parse tip payment config tip_receiver: {:?}", e))?;
+    let block_builder_commission_pct = u64::from_le_bytes(
+        config_account
+            .data()
+            .slice_at(CONFIG_BLOCK_BUILDER_COMMISSION_PCT_BYTE_INDEX, 8)?
+            .try_into()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to parse tip payment config block_builder_commission_pct: {:?}",
+                    e
+                )
+            })?,
+    );
+    Ok((tip_receiver, block_builder_commission_pct))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::account::Account;
+
+    fn config_account(tip_receiver: Pubkey, block_builder: Pubkey, commission_pct: u64) -> Account {
+        let mut data = vec![0_u8; 8];
+        data.extend_from_slice(tip_receiver.as_ref());
+        data.extend_from_slice(block_builder.as_ref());
+        data.extend_from_slice(&commission_pct.to_le_bytes());
+        data.extend_from_slice(&[0_u8; 9]);
+        Account {
+            lamports: 1,
+            data,
+            owner: JITO_TIP_PAYMENT_PROGRAM.try_into().unwrap(),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    #[test]
+    fn parses_tip_payment_config() {
+        let tip_receiver = Pubkey::new_unique();
+        let account = config_account(tip_receiver, Pubkey::new_unique(), 5);
+        let (parsed_receiver, parsed_pct) = parse_tip_payment_config(&account).unwrap();
+        assert_eq!(parsed_receiver, tip_receiver);
+        assert_eq!(parsed_pct, 5);
+    }
+
+    #[test]
+    fn serializes_with_jito_field_names() {
+        let vote_account = Pubkey::new_unique();
+        let collection = JitoStakeMetaCollection {
+            stake_metas: vec![JitoStakeMeta {
+                validator_vote_account: vote_account,
+                validator_node_pubkey: Pubkey::new_unique(),
+                maybe_tip_distribution_meta: Some(JitoTipDistributionMeta {
+                    merkle_root_upload_authority: Pubkey::new_unique(),
+                    tip_distribution_pubkey: Pubkey::new_unique(),
+                    total_tips: 42,
+                    validator_fee_bps: 800,
+                }),
+                maybe_priority_fee_distribution_meta: None,
+                delegations: vec![JitoDelegation {
+                    stake_account_pubkey: Pubkey::new_unique(),
+                    staker_pubkey: Pubkey::new_unique(),
+                    withdrawer_pubkey: Pubkey::new_unique(),
+                    lamports_delegated: 1000,
+                }],
+                total_delegated: 1000,
+                commission: 7,
+            }],
+            tip_distribution_program_id: JITO_PROGRAM.try_into().unwrap(),
+            priority_fee_distribution_program_id: JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM
+                .try_into()
+                .unwrap(),
+            bank_hash: "hash".to_string(),
+            epoch: 1002,
+            slot: 433295999,
+        };
+
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&collection).unwrap()).unwrap();
+        assert_eq!(json["epoch"], 1002);
+        assert_eq!(
+            json["tip_distribution_program_id"],
+            JITO_PROGRAM.to_string()
+        );
+        let stake_meta = &json["stake_metas"][0];
+        assert_eq!(
+            stake_meta["validator_vote_account"],
+            vote_account.to_string()
+        );
+        assert_eq!(stake_meta["commission"], 7);
+        assert_eq!(stake_meta["total_delegated"], 1000);
+        assert_eq!(stake_meta["maybe_tip_distribution_meta"]["total_tips"], 42);
+        assert_eq!(
+            stake_meta["maybe_tip_distribution_meta"]["validator_fee_bps"],
+            800
+        );
+        assert!(stake_meta["maybe_priority_fee_distribution_meta"].is_null());
+        assert_eq!(stake_meta["delegations"][0]["lamports_delegated"], 1000);
+    }
+
+    #[test]
+    fn sorts_delegations_like_jito() {
+        let mut keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        keys.sort();
+        let delegation = |stake_account: Pubkey| JitoDelegation {
+            stake_account_pubkey: stake_account,
+            staker_pubkey: Pubkey::new_unique(),
+            withdrawer_pubkey: Pubkey::new_unique(),
+            lamports_delegated: 1,
+        };
+        let mut delegations = [delegation(keys[1]), delegation(keys[0])];
+        delegations.sort();
+        assert_eq!(delegations[0].stake_account_pubkey, keys[0]);
+        assert_eq!(delegations[1].stake_account_pubkey, keys[1]);
+    }
+
+    #[test]
+    fn delegation_tie_break_orders_withdrawer_before_staker() {
+        let stake_account = Pubkey::new_unique();
+        let mut keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        keys.sort();
+        let delegation = |staker: Pubkey, withdrawer: Pubkey| JitoDelegation {
+            stake_account_pubkey: stake_account,
+            staker_pubkey: staker,
+            withdrawer_pubkey: withdrawer,
+            lamports_delegated: 1,
+        };
+        // the lower staker must lose to the lower withdrawer
+        let mut delegations = [delegation(keys[0], keys[1]), delegation(keys[1], keys[0])];
+        delegations.sort();
+        assert_eq!(delegations[0].withdrawer_pubkey, keys[0]);
+        assert_eq!(delegations[0].staker_pubkey, keys[1]);
+    }
+
+    #[test]
+    fn splits_block_builder_fee() {
+        assert_eq!(split_block_builder_fee(1_000, 0).unwrap(), 1_000);
+        assert_eq!(split_block_builder_fee(1_000, 100).unwrap(), 0);
+        assert_eq!(split_block_builder_fee(1_000, 5).unwrap(), 950);
+        // truncation of the block builder cut must leave the remainder with the tip receiver
+        assert_eq!(split_block_builder_fee(1_001, 5).unwrap(), 951);
+        assert_eq!(split_block_builder_fee(0, 5).unwrap(), 0);
+        assert!(split_block_builder_fee(u64::MAX, 101).is_err());
+    }
+
+    #[test]
+    fn total_tips_credits_the_tip_receiver_only() {
+        let tip_distribution_pubkey = Pubkey::new_unique();
+        let meta = DistributionAccountMeta {
+            pubkey: tip_distribution_pubkey,
+            merkle_root_upload_authority: Pubkey::new_unique(),
+            validator_fee_bps: 800,
+            lamports: 1_000,
+            data_len: 0,
+        };
+
+        assert_eq!(
+            total_tips(&meta, 100, Some((&tip_distribution_pubkey, 50))).unwrap(),
+            950
+        );
+        let other_receiver = Pubkey::new_unique();
+        assert_eq!(
+            total_tips(&meta, 100, Some((&other_receiver, 50))).unwrap(),
+            900
+        );
+        assert_eq!(total_tips(&meta, 100, None).unwrap(), 900);
+        assert!(total_tips(&meta, 2_000, None).is_err());
+    }
+}

--- a/snapshot-parser-validator-cli/src/lib.rs
+++ b/snapshot-parser-validator-cli/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod jito_mev;
 pub mod jito_priority_fee;
+pub mod jito_stake_meta;
+pub mod scanned_accounts;
 pub mod utils;
 pub mod validator_meta;

--- a/snapshot-parser-validator-cli/src/scanned_accounts.rs
+++ b/snapshot-parser-validator-cli/src/scanned_accounts.rs
@@ -1,0 +1,82 @@
+use crate::jito_mev::JITO_PROGRAM;
+use crate::jito_priority_fee::JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM;
+use {
+    log::info, snapshot_parser::account_scan::scan_accounts_by_owner,
+    solana_program::pubkey::Pubkey, solana_runtime::bank::Bank,
+    solana_sdk::account::AccountSharedData, std::collections::HashSet, std::sync::Arc,
+};
+
+pub struct ScannedAccounts {
+    pub stake: Arc<Vec<(Pubkey, AccountSharedData)>>,
+    pub tip_distribution: Arc<Vec<(Pubkey, AccountSharedData)>>,
+    pub priority_fee_distribution: Arc<Vec<(Pubkey, AccountSharedData)>>,
+}
+
+pub fn scan_required_accounts(bank: &Arc<Bank>, verify: bool) -> anyhow::Result<ScannedAccounts> {
+    let stake_program = solana_stake_interface::program::ID;
+    let tip_distribution_program: Pubkey = JITO_PROGRAM.try_into()?;
+    let priority_fee_distribution_program: Pubkey =
+        JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?;
+
+    let mut scanned = scan_accounts_by_owner(
+        bank,
+        &[
+            stake_program,
+            tip_distribution_program,
+            priority_fee_distribution_program,
+        ],
+    )?;
+    let mut take = |owner: &Pubkey| Arc::new(scanned.remove(owner).unwrap_or_default());
+    let scanned_accounts = ScannedAccounts {
+        stake: take(&stake_program),
+        tip_distribution: take(&tip_distribution_program),
+        priority_fee_distribution: take(&priority_fee_distribution_program),
+    };
+
+    if verify {
+        verify_matches_program_accounts(bank, &stake_program, &scanned_accounts.stake)?;
+        verify_matches_program_accounts(
+            bank,
+            &tip_distribution_program,
+            &scanned_accounts.tip_distribution,
+        )?;
+        verify_matches_program_accounts(
+            bank,
+            &priority_fee_distribution_program,
+            &scanned_accounts.priority_fee_distribution,
+        )?;
+    }
+
+    Ok(scanned_accounts)
+}
+
+// Costs one extra full accounts-index scan per owner, which is what the single pass exists to avoid
+fn verify_matches_program_accounts(
+    bank: &Arc<Bank>,
+    owner: &Pubkey,
+    scanned: &[(Pubkey, AccountSharedData)],
+) -> anyhow::Result<()> {
+    let expected = bank.get_program_accounts(owner)?;
+    anyhow::ensure!(
+        scanned.len() == expected.len(),
+        "Account scan mismatch for owner {owner}: single pass produced {} accounts, get_program_accounts produced {}",
+        scanned.len(),
+        expected.len()
+    );
+
+    let scanned_pubkeys: HashSet<Pubkey> = scanned.iter().map(|(pubkey, _)| *pubkey).collect();
+    let expected_pubkeys: HashSet<Pubkey> = expected.iter().map(|(pubkey, _)| *pubkey).collect();
+    anyhow::ensure!(
+        scanned_pubkeys == expected_pubkeys,
+        "Account scan pubkey set mismatch for owner {owner}: {} only in single pass, {} only in get_program_accounts",
+        scanned_pubkeys.difference(&expected_pubkeys).count(),
+        expected_pubkeys.difference(&scanned_pubkeys).count()
+    );
+
+    info!(
+        "Account scan verified against get_program_accounts for owner {}: {} accounts",
+        owner,
+        scanned.len()
+    );
+    Ok(())
+}

--- a/snapshot-parser-validator-cli/src/utils/jito_parser.rs
+++ b/snapshot-parser-validator-cli/src/utils/jito_parser.rs
@@ -1,9 +1,11 @@
 use crate::utils::SliceAt;
 use solana_program::pubkey::Pubkey;
-use solana_sdk::account::Account;
+use solana_sdk::account::ReadableAccount;
 
 // -- Fortunatelly the JITO distribution accounts have the same structure
 const VALIDATOR_VOTE_ACCOUNT_BYTE_INDEX: usize = 8; // anchor header
+const MERKLE_ROOT_UPLOAD_AUTHORITY_BYTE_INDEX: usize = 8 + // anchor header
+    32; // validator vote account
 const MERKLE_ROOT_OPTION_BYTE_INDEX: usize = 8 + // anchor header
     64; // vote account + upload authority
 const EPOCH_CREATED_AT_NO_MERKLE_ROOT_BYTE_INDEX: usize = MERKLE_ROOT_OPTION_BYTE_INDEX // anchor + pubkeys
@@ -13,33 +15,51 @@ const EPOCH_CREATED_AT_WITH_MERKLE_ROOT_BYTE_INDEX: usize =
 const VALIDATOR_COMMISSION_BPS_BYTE_OFFSET: usize = 8;
 
 /// Returns the epoch and the byte index where the epoch was found at.
-pub(crate) fn get_epoch_created_at(account: &Account) -> anyhow::Result<(u64, usize)> {
+pub(crate) fn get_epoch_created_at(account: &impl ReadableAccount) -> anyhow::Result<(u64, usize)> {
     // epoch_created_at_*_byte_index -1 contains info about Option is None (0) or Some (1)
-    if u8::from_le_bytes([account.data[MERKLE_ROOT_OPTION_BYTE_INDEX]]) == 0 {
+    let merkle_root_option = account.data().slice_at(MERKLE_ROOT_OPTION_BYTE_INDEX, 1)?[0];
+    if merkle_root_option == 0 {
         Ok((
             u64::from_le_bytes(
                 account
-                    .data
+                    .data()
                     .slice_at(EPOCH_CREATED_AT_NO_MERKLE_ROOT_BYTE_INDEX, 8)?
                     .try_into()?,
             ),
             EPOCH_CREATED_AT_NO_MERKLE_ROOT_BYTE_INDEX,
         ))
     } else {
-        assert_eq!(
-            u8::from_le_bytes([account.data[MERKLE_ROOT_OPTION_BYTE_INDEX]]),
-            1
+        anyhow::ensure!(
+            merkle_root_option == 1,
+            "Unexpected Option<MerkleRoot> discriminant {merkle_root_option}"
         );
         Ok((
             u64::from_le_bytes(
                 account
-                    .data
+                    .data()
                     .slice_at(EPOCH_CREATED_AT_WITH_MERKLE_ROOT_BYTE_INDEX, 8)?
                     .try_into()?,
             ),
             EPOCH_CREATED_AT_WITH_MERKLE_ROOT_BYTE_INDEX,
         ))
     }
+}
+
+pub(crate) fn read_merkle_root_upload_authority(
+    account_pubkey: Pubkey,
+    account: &impl ReadableAccount,
+) -> anyhow::Result<Pubkey> {
+    account
+        .data()
+        .slice_at(MERKLE_ROOT_UPLOAD_AUTHORITY_BYTE_INDEX, 32)?
+        .try_into()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse merkle_root_upload_authority of account {}: {:?}",
+                account_pubkey,
+                e
+            )
+        })
 }
 
 pub(crate) struct JitoCommissionMeta {
@@ -50,11 +70,11 @@ pub(crate) struct JitoCommissionMeta {
 
 pub(crate) fn read_jito_commission_and_epoch(
     account_pubkey: Pubkey,
-    account: &Account,
+    account: &impl ReadableAccount,
     end_merkle_root_byte_index: usize,
 ) -> anyhow::Result<JitoCommissionMeta> {
     let validator_vote_account: Pubkey = account
-        .data
+        .data()
         .slice_at(VALIDATOR_VOTE_ACCOUNT_BYTE_INDEX, 32)?
         .try_into()
         .map_err(|e| {
@@ -67,7 +87,7 @@ pub(crate) fn read_jito_commission_and_epoch(
 
     let epoch_created_at: u64 = u64::from_le_bytes(
         account
-            .data
+            .data()
             .slice_at(end_merkle_root_byte_index, 8)?
             .try_into()
             .map_err(|e| {
@@ -83,7 +103,7 @@ pub(crate) fn read_jito_commission_and_epoch(
         end_merkle_root_byte_index + VALIDATOR_COMMISSION_BPS_BYTE_OFFSET;
     let validator_commission_bps = u16::from_le_bytes(
         account
-            .data
+            .data()
             .slice_at(validator_commission_bps_byte_index, 2)?
             .try_into()
             .map_err(|e| {

--- a/snapshot-parser-validator-cli/src/validator_meta.rs
+++ b/snapshot-parser-validator-cli/src/validator_meta.rs
@@ -7,7 +7,7 @@ use {
     snapshot_parser::utils::lamports_to_sol,
     solana_program::pubkey::Pubkey,
     solana_runtime::bank::Bank,
-    solana_sdk::epoch_info::EpochInfo,
+    solana_sdk::{account::AccountSharedData, epoch_info::EpochInfo},
     solana_stake_interface::stake_history::Epoch,
     std::{fmt::Debug, sync::Arc},
 };
@@ -110,7 +110,11 @@ fn fetch_vote_account_metas(bank: &Arc<Bank>, epoch: Epoch) -> Vec<VoteAccountMe
         .collect()
 }
 
-pub fn generate_validator_collection(bank: &Arc<Bank>) -> anyhow::Result<ValidatorMetaCollection> {
+pub fn generate_validator_collection(
+    bank: &Arc<Bank>,
+    tip_distribution_accounts: &[(Pubkey, AccountSharedData)],
+    priority_fee_distribution_accounts: &[(Pubkey, AccountSharedData)],
+) -> anyhow::Result<ValidatorMetaCollection> {
     assert!(bank.is_frozen());
 
     let EpochInfo {
@@ -128,8 +132,9 @@ pub fn generate_validator_collection(bank: &Arc<Bank>) -> anyhow::Result<Validat
         (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
 
     let vote_account_metas = fetch_vote_account_metas(bank, epoch);
-    let jito_mev_metas = fetch_jito_mev_metas(bank, epoch)?;
-    let jito_priority_fee_metas = fetch_jito_priority_fee_metas(bank, epoch)?;
+    let jito_mev_metas = fetch_jito_mev_metas(tip_distribution_accounts, epoch)?;
+    let jito_priority_fee_metas =
+        fetch_jito_priority_fee_metas(priority_fee_distribution_accounts, epoch)?;
 
     let mut validator_metas = vote_account_metas
         .into_iter()

--- a/snapshot-parser/Cargo.toml
+++ b/snapshot-parser/Cargo.toml
@@ -21,3 +21,7 @@ solana-sdk = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-stake-interface = { workspace = true }
 
+[dev-dependencies]
+# dev-context-only-utils gates Bank::new_for_tests; resolver = "2" keeps it out of the normal build
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -1,0 +1,100 @@
+use {
+    log::info,
+    solana_accounts_db::is_loadable::IsLoadable,
+    solana_program::pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+    solana_sdk::account::{AccountSharedData, ReadableAccount},
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    },
+};
+
+// get_program_accounts is a full accounts-index scan per call, so one call per owner costs N passes
+pub fn scan_accounts_by_owner(
+    bank: &Arc<Bank>,
+    owners: &[Pubkey],
+) -> anyhow::Result<HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>>> {
+    let wanted: HashSet<Pubkey> = owners.iter().copied().collect();
+    let mut collected: HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>> =
+        wanted.iter().map(|owner| (*owner, Vec::new())).collect();
+
+    bank.scan_all_accounts(|maybe_account| {
+        let Some((pubkey, account, _slot)) = maybe_account else {
+            return;
+        };
+        // the same predicate get_program_accounts filters on, not a copy of it
+        if !account.is_loadable() {
+            return;
+        }
+        if let Some(accounts) = collected.get_mut(account.owner()) {
+            accounts.push((*pubkey, account));
+        }
+    })?;
+
+    for (owner, accounts) in &collected {
+        info!("Accounts scanned for owner {}: {}", owner, accounts.len());
+    }
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use {
+        solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        solana_sdk::account::Account,
+        std::collections::BTreeSet,
+    };
+
+    fn pubkeys(accounts: &[(Pubkey, AccountSharedData)]) -> BTreeSet<Pubkey> {
+        accounts.iter().map(|(pubkey, _)| *pubkey).collect()
+    }
+
+    #[test]
+    fn one_pass_matches_get_program_accounts_per_owner() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1_000_000);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let wanted_owners = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let ignored_owner = Pubkey::new_unique();
+        let store = |owner: &Pubkey, lamports: u64| {
+            let pubkey = Pubkey::new_unique();
+            bank.store_account(
+                &pubkey,
+                &AccountSharedData::from(Account {
+                    lamports,
+                    data: vec![1, 2, 3],
+                    owner: *owner,
+                    executable: false,
+                    rent_epoch: 0,
+                }),
+            );
+            pubkey
+        };
+
+        let first = [store(&wanted_owners[0], 10), store(&wanted_owners[0], 20)];
+        let second = [store(&wanted_owners[1], 30)];
+        store(&ignored_owner, 40);
+
+        let scanned = scan_accounts_by_owner(&bank, &wanted_owners).unwrap();
+
+        assert_eq!(pubkeys(&scanned[&wanted_owners[0]]), pubkeys_of(&first));
+        assert_eq!(pubkeys(&scanned[&wanted_owners[1]]), pubkeys_of(&second));
+        assert!(!scanned.contains_key(&ignored_owner));
+
+        // the is_loadable() skip is not covered: a test bank drops zero-lamport accounts before the scan
+        for owner in &wanted_owners {
+            assert_eq!(
+                pubkeys(&scanned[owner]),
+                pubkeys(&bank.get_program_accounts(owner).unwrap()),
+                "single pass diverged from get_program_accounts for owner {owner}"
+            );
+        }
+    }
+
+    fn pubkeys_of(keys: &[Pubkey]) -> BTreeSet<Pubkey> {
+        keys.iter().copied().collect()
+    }
+}

--- a/snapshot-parser/src/lib.rs
+++ b/snapshot-parser/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod account_scan;
 pub mod bank_loader;
 pub mod cli;
 pub mod serde_serialize;
+pub mod stake_activation;
 pub mod stake_meta;
 pub mod utils;

--- a/snapshot-parser/src/stake_activation.rs
+++ b/snapshot-parser/src/stake_activation.rs
@@ -5,7 +5,6 @@ use {
         stake_history::{Epoch, StakeHistory, StakeHistoryEntry},
         state::Delegation,
     },
-    std::sync::Arc,
 };
 
 // Owns the warmup/cooldown rate so no caller can pass one and re-pin the pre-activation 25% rate
@@ -16,7 +15,7 @@ pub struct StakeActivation {
 }
 
 impl StakeActivation {
-    pub fn new(bank: &Arc<Bank>) -> anyhow::Result<Self> {
+    pub fn new(bank: &Bank) -> anyhow::Result<Self> {
         let history_account = bank
             .get_account(&solana_stake_interface::sysvar::stake_history::ID)
             .ok_or_else(|| anyhow::anyhow!("Failed to fetch the stake history sysvar"))?;
@@ -53,7 +52,10 @@ impl StakeActivation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use {
+        solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        std::sync::Arc,
+    };
 
     #[test]
     fn rate_comes_from_the_bank_and_is_never_none() {

--- a/snapshot-parser/src/stake_activation.rs
+++ b/snapshot-parser/src/stake_activation.rs
@@ -1,0 +1,76 @@
+use {
+    solana_runtime::bank::Bank,
+    solana_sdk::account::ReadableAccount,
+    solana_stake_interface::{
+        stake_history::{Epoch, StakeHistory, StakeHistoryEntry},
+        state::Delegation,
+    },
+    std::sync::Arc,
+};
+
+// Owns the warmup/cooldown rate so no caller can pass one and re-pin the pre-activation 25% rate
+pub struct StakeActivation {
+    epoch: Epoch,
+    history: StakeHistory,
+    new_rate_activation_epoch: Option<Epoch>,
+}
+
+impl StakeActivation {
+    pub fn new(bank: &Arc<Bank>) -> anyhow::Result<Self> {
+        let history_account = bank
+            .get_account(&solana_stake_interface::sysvar::stake_history::ID)
+            .ok_or_else(|| anyhow::anyhow!("Failed to fetch the stake history sysvar"))?;
+
+        Ok(Self {
+            epoch: bank.epoch(),
+            history: bincode::deserialize(history_account.data())?,
+            new_rate_activation_epoch: bank.new_warmup_cooldown_rate_epoch(),
+        })
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    pub fn new_rate_activation_epoch(&self) -> Option<Epoch> {
+        self.new_rate_activation_epoch
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    pub fn status(&self, delegation: &Delegation) -> StakeHistoryEntry {
+        delegation.stake_activating_and_deactivating(
+            self.epoch,
+            &self.history,
+            self.new_rate_activation_epoch,
+        )
+    }
+
+    pub fn effective(&self, delegation: &Delegation) -> u64 {
+        self.status(delegation).effective
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+
+    #[test]
+    fn rate_comes_from_the_bank_and_is_never_none() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1_000_000);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let activation = StakeActivation::new(&bank).unwrap();
+
+        // `None` here would select the 25% rate regardless of the cluster — the defect this pins
+        assert_eq!(
+            activation.new_rate_activation_epoch(),
+            bank.new_warmup_cooldown_rate_epoch()
+        );
+        assert!(
+            activation.new_rate_activation_epoch().is_some(),
+            "reduce_stake_warmup_cooldown is active on a test genesis, so the rate epoch must be Some"
+        );
+        assert_eq!(activation.epoch(), bank.epoch());
+    }
+}

--- a/snapshot-parser/src/stake_meta.rs
+++ b/snapshot-parser/src/stake_meta.rs
@@ -1,13 +1,17 @@
 use {
     crate::serde_serialize::{option_pubkey_string_conversion, pubkey_string_conversion},
+    crate::stake_activation::StakeActivation,
     crate::utils::lamports_to_sol,
     log::{error, info},
     serde::{Deserialize, Serialize},
     solana_program::pubkey::Pubkey,
     solana_runtime::bank::Bank,
-    solana_sdk::{account::Account, epoch_info::EpochInfo},
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        epoch_info::EpochInfo,
+    },
     solana_stake_interface::{
-        stake_history::{Epoch, StakeHistory, StakeHistoryEntry},
+        stake_history::{Epoch, StakeHistoryEntry},
         state::StakeStateV2,
     },
     std::{fmt::Debug, sync::Arc},
@@ -48,31 +52,34 @@ pub struct StakeMetaCollection {
     pub stake_metas: Vec<StakeMeta>,
 }
 
+fn load_stake_accounts(bank: &Arc<Bank>) -> anyhow::Result<Vec<(Pubkey, AccountSharedData)>> {
+    let stake_accounts_raw = bank.get_program_accounts(&solana_stake_interface::program::ID)?;
+    info!("Stake processors loaded: {}", stake_accounts_raw.len());
+
+    Ok(stake_accounts_raw)
+}
+
 pub fn generate_stake_meta_collection(bank: &Arc<Bank>) -> anyhow::Result<StakeMetaCollection> {
+    generate_stake_meta_collection_for_accounts(bank, &load_stake_accounts(bank)?)
+}
+
+pub fn generate_stake_meta_collection_for_accounts(
+    bank: &Arc<Bank>,
+    stake_accounts: &[(Pubkey, AccountSharedData)],
+) -> anyhow::Result<StakeMetaCollection> {
     assert!(bank.is_frozen());
 
-    let EpochInfo {
-        epoch,
-        absolute_slot,
-        ..
-    } = bank.get_epoch_info();
+    let EpochInfo { absolute_slot, .. } = bank.get_epoch_info();
 
-    let history_account = Account::from(
-        bank.get_account(&solana_stake_interface::sysvar::stake_history::ID)
-            .expect("Failed to fetch the stake history"),
-    );
-    let history: StakeHistory = bincode::deserialize(&history_account.data)?;
+    let stake_activation = StakeActivation::new(bank)?;
+    let epoch = stake_activation.epoch();
     info!("Stake history loaded.");
-
-    let stake_accounts_raw = bank.get_program_accounts(&solana_stake_interface::program::ID)?;
-
-    info!("Stake processors loaded: {}", stake_accounts_raw.len());
 
     let mut stake_metas: Vec<StakeMeta> = Default::default();
 
-    for (pubkey, shared_account) in stake_accounts_raw {
-        let account = Account::from(shared_account);
-        let stake_account: StakeStateV2 = match bincode::deserialize(&account.data) {
+    for (pubkey, shared_account) in stake_accounts {
+        let pubkey = *pubkey;
+        let stake_account: StakeStateV2 = match bincode::deserialize(shared_account.data()) {
             Ok(account) => account,
             Err(err) => {
                 error!("Error parsing stake account {}: {}", pubkey, err);
@@ -91,9 +98,7 @@ pub fn generate_stake_meta_collection(bank: &Arc<Bank>) -> anyhow::Result<StakeM
                     effective,
                     activating,
                     deactivating,
-                } = stake
-                    .delegation
-                    .stake_activating_and_deactivating(epoch, &history, None);
+                } = stake_activation.status(&stake.delegation);
                 (
                     Some(stake.delegation.voter_pubkey),
                     effective,
@@ -106,7 +111,7 @@ pub fn generate_stake_meta_collection(bank: &Arc<Bank>) -> anyhow::Result<StakeM
 
         stake_metas.push(StakeMeta {
             pubkey,
-            balance_lamports: account.lamports,
+            balance_lamports: shared_account.lamports(),
             active_delegation_lamports,
             activating_delegation_lamports,
             deactivating_delegation_lamports,
@@ -120,6 +125,12 @@ pub fn generate_stake_meta_collection(bank: &Arc<Bank>) -> anyhow::Result<StakeM
         })
     }
     info!("Collected all stake account metas: {}", stake_metas.len());
+
+    if stake_metas.is_empty() {
+        anyhow::bail!(
+            "Not expected. No stake metas collected for epoch {epoch}. Evaluate the snapshot data."
+        );
+    }
 
     let total_active: u64 = stake_metas
         .iter()

--- a/snapshot-parser/src/utils.rs
+++ b/snapshot-parser/src/utils.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use solana_native_token::LAMPORTS_PER_SOL;
 use std::path::Path;
 use std::{
+    fs,
     fs::File,
     io::{BufReader, BufWriter, Write},
 };
@@ -11,14 +12,46 @@ pub fn lamports_to_sol(lamports: u64) -> f64 {
     lamports as f64 / LAMPORTS_PER_SOL as f64
 }
 
-pub fn write_to_json_file<T: Serialize>(data: &T, out_path: &str) -> anyhow::Result<()> {
-    let file = File::create(out_path)?;
-    let mut writer = BufWriter::new(file);
-    let json = serde_json::to_string_pretty(data)?;
-    writer.write_all(json.as_bytes())?;
-    writer.flush()?;
+// The pipeline treats an existing file as a complete one, so a partial write must never reach it
+fn write_atomic<F>(out_path: &str, write: F) -> anyhow::Result<()>
+where
+    F: FnOnce(&mut BufWriter<File>) -> anyhow::Result<()>,
+{
+    let tmp_path = format!("{out_path}.tmp");
+    let result = (|| {
+        let mut writer = BufWriter::new(File::create(&tmp_path)?);
+        write(&mut writer)?;
+        writer.flush()?;
+        writer
+            .into_inner()
+            .map_err(|err| anyhow::anyhow!("Failed to flush {tmp_path}: {err}"))?
+            .sync_all()?;
+
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+        return result;
+    }
+    fs::rename(&tmp_path, out_path)?;
 
     Ok(())
+}
+
+pub fn write_to_json_file<T: Serialize>(data: &T, out_path: &str) -> anyhow::Result<()> {
+    write_atomic(out_path, |writer| {
+        serde_json::to_writer_pretty(writer, data)?;
+
+        Ok(())
+    })
+}
+
+pub fn write_to_json_file_compact<T: Serialize>(data: &T, out_path: &str) -> anyhow::Result<()> {
+    write_atomic(out_path, |writer| {
+        serde_json::to_writer(writer, data)?;
+
+        Ok(())
+    })
 }
 
 pub fn read_from_json_file<P: AsRef<Path>, T: DeserializeOwned>(in_path: &P) -> anyhow::Result<T> {
@@ -27,4 +60,79 @@ pub fn read_from_json_file<P: AsRef<Path>, T: DeserializeOwned>(in_path: &P) -> 
     let result: T = serde_json::from_reader(reader)?;
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // A fixed name in the shared temp dir collides between concurrent test runs on one host
+    struct OutDir(std::path::PathBuf);
+
+    impl OutDir {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "snapshot-parser-{name}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn path(&self) -> String {
+            self.0.join("out.json").to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for OutDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn pretty_writer_keeps_the_previous_artifact_bytes() {
+        let data = json!({"epoch": 1002, "stake_metas": [{"pubkey": "abc", "lamports": 1}]});
+        let out = OutDir::new("pretty");
+        write_to_json_file(&data, &out.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(out.path()).unwrap(),
+            serde_json::to_string_pretty(&data).unwrap()
+        );
+    }
+
+    #[test]
+    fn writers_leave_no_temporary_file_behind() {
+        let data = json!({"epoch": 1002});
+        let out = OutDir::new("no-tmp");
+        write_to_json_file_compact(&data, &out.path()).unwrap();
+
+        assert_eq!(fs::read_to_string(out.path()).unwrap(), r#"{"epoch":1002}"#);
+        assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
+    }
+
+    #[test]
+    fn a_failing_serialization_leaves_the_destination_untouched() {
+        let out = OutDir::new("preserved");
+        write_to_json_file_compact(&json!({"complete": true}), &out.path()).unwrap();
+
+        assert!(write_to_json_file_compact(&NonSerializable, &out.path()).is_err());
+        assert_eq!(
+            fs::read_to_string(out.path()).unwrap(),
+            r#"{"complete":true}"#,
+            "a failed write must not clobber the previous complete file"
+        );
+        assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
+    }
+
+    struct NonSerializable;
+
+    impl Serialize for NonSerializable {
+        fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("boom"))
+        }
+    }
 }

--- a/snapshot-parser/src/utils.rs
+++ b/snapshot-parser/src/utils.rs
@@ -46,14 +46,6 @@ pub fn write_to_json_file<T: Serialize>(data: &T, out_path: &str) -> anyhow::Res
     })
 }
 
-pub fn write_to_json_file_compact<T: Serialize>(data: &T, out_path: &str) -> anyhow::Result<()> {
-    write_atomic(out_path, |writer| {
-        serde_json::to_writer(writer, data)?;
-
-        Ok(())
-    })
-}
-
 pub fn read_from_json_file<P: AsRef<Path>, T: DeserializeOwned>(in_path: &P) -> anyhow::Result<T> {
     let file = File::open(in_path)?;
     let reader = BufReader::new(file);
@@ -108,21 +100,25 @@ mod tests {
     fn writers_leave_no_temporary_file_behind() {
         let data = json!({"epoch": 1002});
         let out = OutDir::new("no-tmp");
-        write_to_json_file_compact(&data, &out.path()).unwrap();
+        write_to_json_file(&data, &out.path()).unwrap();
 
-        assert_eq!(fs::read_to_string(out.path()).unwrap(), r#"{"epoch":1002}"#);
+        assert_eq!(
+            fs::read_to_string(out.path()).unwrap(),
+            serde_json::to_string_pretty(&data).unwrap()
+        );
         assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
     }
 
     #[test]
     fn a_failing_serialization_leaves_the_destination_untouched() {
+        let complete = json!({"complete": true});
         let out = OutDir::new("preserved");
-        write_to_json_file_compact(&json!({"complete": true}), &out.path()).unwrap();
+        write_to_json_file(&complete, &out.path()).unwrap();
 
-        assert!(write_to_json_file_compact(&NonSerializable, &out.path()).is_err());
+        assert!(write_to_json_file(&NonSerializable, &out.path()).is_err());
         assert_eq!(
             fs::read_to_string(out.path()).unwrap(),
-            r#"{"complete":true}"#,
+            serde_json::to_string_pretty(&complete).unwrap(),
             "a failed write must not clobber the previous complete file"
         );
         assert!(!Path::new(&format!("{}.tmp", out.path())).exists());


### PR DESCRIPTION
  Generate a Jito-format stake meta collection from our own snapshot, so tip distribution no longer depends on Jito finalizing their pipeline in time.

- Add an optional `jito-stake-meta.json` replicating Jito's `stake_meta_generator`, kept non-fatal so Jito-side changes cannot break the epoch parse
- Collapse the validator CLI's three full accounts-index scans into one, with `--verify-account-scan` to cross-check it against the old path
- Write JSON outputs atomically and streamed, so a failed write cannot publish a truncated file or hold the whole document in memory
- Derive the stake warmup/cooldown rate from the bank's feature set rather than forcing the pre-activation branch, and route it through one wrapper so no caller can pin it again — this changes `stakes.json` activating and deactivating amounts
- Refuse to emit an empty stake or Jito collection, and fail the Jito one when undistributed tips would otherwise be dropped
- Publish the new artifact from Buildkite, annotating the build when the collection was not produced
- Run `cargo test` in CI, widen clippy to the whole workspace, and move to `resolver = "2"` so bank test helpers stay out of release builds

---

**Stage 1**: 

**Goal**: avoid being fully dependent on the Jito processing pipeline for tip generation. This is meant as a backup plan in case Jito is unable to finalize their processing in time, like yesterday when it took around 12 hours.

My plan is:

a) Review and finalize the implementation, then launch it.
b) Run it in parallel and, after a few epochs, validate that our parsing and calculations match what Jito provides.
c) Find the right place to store this calculation separately from what Jito generates, possibly under a suffixed name.
d) When needed, we will have the option to use Jito tips calculated from our snapshot.

I’m not sure we should fully switch to our own processing. We would need to closely follow how Jito performs their calculations, and if they change anything, we would need to react quite quickly.


As a follow-up, verify this statement

```text
The TipRouter fee is not taken from the validator's part. It comes out of the stakers' part, so the staker values stakes-etl computes are overstated.

Here's the actual on-chain distribution, from jito-tip-router/meta_merkle_tree/src/generated_merkle_tree.rs (vec_from_stake_meta_for_distribution_meta, the code that builds the merkle tree people actually claim against):

let protocol_fee_amount = mul_div(total_tips, protocol_fee_bps, MAX_BPS)?;
let validator_amount = mul_div(total_tips, validator_fee_bps, MAX_BPS)?;
// stakers:
remaining_total_rewards = total_tips - protocol_fee_amount - validator_amount

Both fees are computed on the full total_tips, and the delegators pro-rate only the remainder. The validator's commission is untouched by the protocol fee (except an edge case where protocol_fee + validator_amount > total_tips, then the protocol fee is preserved and the validator amount is reduced).

Comparing with stakes-etl/etl/src/jito.rs:

- MEV tips (generate_mev_collection) — validator: total_tips * validator_fee_bps / 10_000 → matches on-chain exactly. Stakers: total_tips − validator_amount pro-rata → too high by protocol_fee_bps of total_tips (the NCN base-reward node's share; the TipRouter fee has been 3.00% = 300 bps, read from the  on-chain NCN config).
- Priority fees (generate_priority_fee_collection) — ETL gives stakers 100% of total_tips. On-chain, the hardcoded 0 is validator_fee_bps (validators keep their cut by simply not transferring it into the PFDA), but a separate pf_distribution_protocol_fee_bps protocol fee is still deducted before stakers get the remainder. So priority-fee staker amounts are also overstated by that fee.

So per staker the ETL number is roughly actual_claimable / (1 − protocol_fee_bps/10_000) — about 3% high on MEV, and high by the PF protocol fee bps on priority fees. Important context: this is not something the new self-generated file introduces — it's how stakes-etl has always interpreted Jito's own file, and both files carry the same pre-fee total_tips. The investigation doc's caveat ("jito-etl already pro-rates raw total_tips, so downstream numbers are unchanged in kind") describes exactly this.

Whether it's a problem depends on what the staker records feed: if they're meant to equal what stakers can actually claim from the distribution accounts, the ETL should also subtract the protocol fee (both bps values live in the on-chain TipRouter NCN config, so it'd be either a config constant or an on-chain read in stakes-etl). If they're used as a relative/pro-rata basis only, the 3% uniform scaling washes out.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generation and optional export of Jito stake metadata, including delegation, commission, tip, and priority-fee information.
  * Added account scanning and verification to improve snapshot-derived metadata accuracy.
  * Improved stake activation and effective-stake calculations using current bank state.

* **Bug Fixes**
  * Output files are now written atomically, preventing incomplete files from replacing valid results.
  * Improved error reporting for failed metadata generation and invalid account data.

* **Tests**
  * Expanded coverage for account scanning, stake activation, metadata serialization, fee calculations, and safe file writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->