### PR TITLE
[gh] fix static analysis failures [trivial]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -9091,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/snapshot-parser-tokens-cli/Cargo.toml
+++ b/snapshot-parser-tokens-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "snapshot-parser-tokens-cli"
 path = "src/bin/cli.rs"
 
 [package]
+publish = false
 name = "snapshot-parser-tokens-cli"
 version = "0.0.0"
 edition = "2021"

--- a/snapshot-parser-validator-cli/Cargo.toml
+++ b/snapshot-parser-validator-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "snapshot-parser-validator-cli"
 path = "src/bin/cli.rs"
 
 [package]
+publish = false
 name = "snapshot-parser-validator-cli"
 version = "0.0.0"
 edition = "2021"

--- a/snapshot-parser/Cargo.toml
+++ b/snapshot-parser/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "snapshot-parser"
 version = "0.0.0"
 edition = "2021"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package release settings to prevent internal command-line tools and parser components from being published as public packages.
* **Documentation**
  * Clarified that Solana snapshot parsing produces JSON files for downstream pipeline processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->