### PR TITLE
[GEN-8711] Stage cargo binary at target/release for CARGO_TARGET_DIR-aware Buildkite agents

### DIFF
--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -119,13 +119,7 @@ steps:
     commands:
     - . "$HOME/.cargo/env"
     - cargo build --release --bin snapshot-parser-validator-cli
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache dir; stage the binary back for artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/snapshot-parser-validator-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/snapshot-parser-validator-cli'
     artifact_paths:
       - target/release/snapshot-parser-validator-cli
 

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -119,6 +119,13 @@ steps:
     commands:
     - . "$HOME/.cargo/env"
     - cargo build --release --bin snapshot-parser-validator-cli
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache dir; stage the binary back for artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/snapshot-parser-validator-cli" target/release/
+      fi
     artifact_paths:
       - target/release/snapshot-parser-validator-cli
 


### PR DESCRIPTION
Buildkite agents will soon export `CARGO_TARGET_DIR` globally (agent `environment` hook pointing at a host build cache under `/mnt/storage-1/cargo-target/<pipeline>-<repo>-<commit>-<rustc-hash>`), so `cargo build` output will no longer land in `./target/release`.

This adds a staging block after `cargo build --release --bin snapshot-parser-validator-cli` in `.buildkite/snapshot-fetch-and-parse.yml`: when `CARGO_TARGET_DIR` is set, the binary is copied back into `./target/release/` so `artifact_paths` and the Parse step's download/run keep working unchanged. When the variable is unset the block is a no-op, so this is safe to merge ahead of the hook.

References are `$$`-escaped for job-runtime expansion. Verified: YAML parses, bin name consistent across build/stage/upload/download/run sites, rendered snippet executed in both modes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEGbV86P2XNoY8Jq6CMg6D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now reliably include the compiled binary when using a custom build output directory.
  * Existing builds using the default output directory remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->