### PR TITLE
[GEN-8744] Parallel storage-level account scan: 56 min → 5 s

### DIFF
--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -187,6 +187,7 @@ steps:
   - wait: ~
 
   - label: ":gear: Trigger Stakes ETL to speed up pipeline processing"
+    if: build.env("TEST_MODE") == null
     env:
       TRIGGER_BRANCH: "main"
     commands:

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -162,6 +162,19 @@ steps:
     - previous_epoch=$((epoch - 1))
     - gcloud storage cp "$GCLOUD_SNAPSHOTS/$$previous_epoch/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/past-validators.json" || echo "Previous validator data not available!"
 
+  # TEMP(GEN-8744): revert before merge -- exposes TEST_MODE outputs for byte-comparison against production
+  - label: ":floppy_disk: :arrow_right: :cloud: [TEMP] Upload TEST_MODE outputs for comparison"
+    if: build.env("TEST_MODE") != null
+    commands:
+    - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
+    - epoch=$(buildkite-agent meta-data get epoch)
+    - |
+      for f in validators.json stakes.json jito-stake-meta.json; do
+        if [[ -f "$$snapshot_dir/$$f" ]]; then
+          gcloud storage cp "$$snapshot_dir/$$f" "$GCLOUD_SNAPSHOTS/test-runs/$$epoch-build$$BUILDKITE_BUILD_NUMBER/"
+        fi
+      done
+
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
     if: build.env("TEST_MODE") == null
     commands:

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -162,19 +162,6 @@ steps:
     - previous_epoch=$((epoch - 1))
     - gcloud storage cp "$GCLOUD_SNAPSHOTS/$$previous_epoch/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/past-validators.json" || echo "Previous validator data not available!"
 
-  # TEMP(GEN-8744): revert before merge -- exposes TEST_MODE outputs for byte-comparison against production
-  - label: ":floppy_disk: :arrow_right: :cloud: [TEMP] Upload TEST_MODE outputs for comparison"
-    if: build.env("TEST_MODE") != null
-    commands:
-    - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
-    - epoch=$(buildkite-agent meta-data get epoch)
-    - |
-      for f in validators.json stakes.json jito-stake-meta.json; do
-        if [[ -f "$$snapshot_dir/$$f" ]]; then
-          gcloud storage cp "$$snapshot_dir/$$f" "$GCLOUD_SNAPSHOTS/test-runs/$$epoch-build$$BUILDKITE_BUILD_NUMBER/"
-        fi
-      done
-
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
     if: build.env("TEST_MODE") == null
     commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,6 +5266,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "log",
+ "rayon",
  "serde",
  "serde_json",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ env_logger = "0.11.10"
 indicatif = { version = "0.18.4"}
 log = "0.4.29"
 mpl-token-metadata = "5.1.0"
+rayon = "1.12.0"
 spl-token = { version = "9.0.0" }
 rusqlite = { version = "0.39.0", features = ["bundled", "fallible_uint"] }
 serde = "1.0.228"

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -182,7 +182,10 @@ fn main() -> anyhow::Result<()> {
     }
 
     info!("Finished.");
-    Ok(())
+    log::logger().flush();
+
+    // Outputs are already flushed and synced, so skip the accounts-db teardown of a dying process
+    std::process::exit(0);
 }
 
 #[cfg(test)]

--- a/snapshot-parser/Cargo.toml
+++ b/snapshot-parser/Cargo.toml
@@ -9,6 +9,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 bincode = { workspace = true }
 log = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -1,36 +1,110 @@
 use {
     log::info,
-    solana_accounts_db::is_loadable::IsLoadable,
+    rayon::prelude::*,
+    solana_accounts_db::{
+        accounts_db::{LoadHint, PopulateReadCache},
+        is_loadable::IsLoadable,
+    },
     solana_program::pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     std::{
         collections::{HashMap, HashSet},
         sync::Arc,
+        time::Instant,
     },
 };
 
-// get_program_accounts is a full accounts-index scan per call, so one call per owner costs N passes
+/// Collects every live account owned by one of `owners`, in two phases.
+///
+/// Phase 1 sweeps the snapshot storages in parallel and keeps only pubkeys, never account data.
+/// It yields a superset: a storage holds stale versions, and the same pubkey appears in every
+/// storage it was ever written to. Phase 2 re-loads each candidate through the accounts index,
+/// which is what narrows the superset down to exactly what `get_program_accounts` returns.
+///
+/// The alternative, `Bank::scan_all_accounts`, walks the index in pubkey order and does one
+/// random storage read per account, single threaded.
 pub fn scan_accounts_by_owner(
     bank: &Arc<Bank>,
     owners: &[Pubkey],
 ) -> anyhow::Result<HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>>> {
     let wanted: HashSet<Pubkey> = owners.iter().copied().collect();
+
+    // Accounts still in the write cache have no storage for phase 1 to find. Flushing first is
+    // agave's own pre-snapshot sequence; on a bank freshly loaded from a full snapshot the cache
+    // is empty and this costs nothing.
+    bank.force_flush_accounts_cache();
+
+    let sweep_started = Instant::now();
+    let storages = bank.get_snapshot_storages(None);
+    let storage_count = storages.len();
+    let candidates: HashSet<Pubkey> = storages
+        .par_iter()
+        .try_fold(HashSet::<Pubkey>::new, |mut candidates, storage| {
+            storage
+                .accounts
+                .scan_accounts_without_data(|_offset, account| {
+                    // A live account is loadable, so a zero-lamport stored version is either
+                    // stale or a tombstone and can never be the one we end up keeping.
+                    if account.lamports != 0 && wanted.contains(account.owner) {
+                        candidates.insert(*account.pubkey);
+                    }
+                })?;
+            anyhow::Ok(candidates)
+        })
+        .try_reduce(HashSet::new, |mut merged, mut other| {
+            if merged.len() < other.len() {
+                std::mem::swap(&mut merged, &mut other);
+            }
+            merged.extend(other);
+            anyhow::Ok(merged)
+        })?;
+    // HashSet iteration order is randomised per process, and `collect` below preserves the input
+    // order, so without this the result vecs come out in a different order on every run of the
+    // same snapshot. Sorting restores the run-to-run reproducibility the index scan had, and
+    // groups the phase 2 lookups by accounts-index bin.
+    let mut candidates: Vec<Pubkey> = candidates.into_iter().collect();
+    candidates.sort_unstable();
+    info!(
+        "Storage sweep: {} candidate pubkeys from {} storages in {:?}",
+        candidates.len(),
+        storage_count,
+        sweep_started.elapsed()
+    );
+
+    let confirm_started = Instant::now();
+    let accounts_db = &bank.rc.accounts.accounts_db;
+    let confirmed: Vec<(Pubkey, AccountSharedData)> = candidates
+        .par_iter()
+        .filter_map(|pubkey| {
+            // What Bank::get_account does, minus filling the read-only cache: every candidate is
+            // touched exactly once here, so caching them would only evict useful entries.
+            let (account, _slot) = accounts_db.load(
+                &bank.ancestors,
+                pubkey,
+                LoadHint::Unspecified,
+                PopulateReadCache::False,
+            )?;
+            // the same predicate get_program_accounts filters on, not a copy of it
+            (account.is_loadable() && wanted.contains(account.owner()))
+                .then_some((*pubkey, account))
+        })
+        .collect();
+    info!(
+        "Liveness confirm: {} of {} candidates live in {:?}",
+        confirmed.len(),
+        candidates.len(),
+        confirm_started.elapsed()
+    );
+
     let mut collected: HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>> =
         wanted.iter().map(|owner| (*owner, Vec::new())).collect();
-
-    bank.scan_all_accounts(|maybe_account| {
-        let Some((pubkey, account, _slot)) = maybe_account else {
-            return;
-        };
-        // the same predicate get_program_accounts filters on, not a copy of it
-        if !account.is_loadable() {
-            return;
+    for (pubkey, account) in confirmed {
+        let owner = *account.owner();
+        if let Some(accounts) = collected.get_mut(&owner) {
+            accounts.push((pubkey, account));
         }
-        if let Some(accounts) = collected.get_mut(account.owner()) {
-            accounts.push((*pubkey, account));
-        }
-    })?;
+    }
 
     for (owner, accounts) in &collected {
         info!("Accounts scanned for owner {}: {}", owner, accounts.len());
@@ -48,8 +122,56 @@ mod tests {
         std::collections::BTreeSet,
     };
 
+    /// Deliberately not a plain `collect`: a `BTreeSet` would swallow a repeated pubkey, and a
+    /// repeated pubkey is exactly what a broken phase 1 dedupe produces. Downstream that would
+    /// double count a stake account, so every comparison below has to reject it.
     fn pubkeys(accounts: &[(Pubkey, AccountSharedData)]) -> BTreeSet<Pubkey> {
-        accounts.iter().map(|(pubkey, _)| *pubkey).collect()
+        let pubkeys: BTreeSet<Pubkey> = accounts.iter().map(|(pubkey, _)| *pubkey).collect();
+        assert_eq!(
+            pubkeys.len(),
+            accounts.len(),
+            "the same pubkey was returned more than once"
+        );
+        pubkeys
+    }
+
+    fn pubkeys_of(keys: &[Pubkey]) -> BTreeSet<Pubkey> {
+        keys.iter().copied().collect()
+    }
+
+    fn account(owner: &Pubkey, lamports: u64, data: Vec<u8>) -> AccountSharedData {
+        AccountSharedData::from(Account {
+            lamports,
+            data,
+            owner: *owner,
+            executable: false,
+            rent_epoch: 0,
+        })
+    }
+
+    /// Phase 1 only sees storages, so a test bank has to root and flush its write cache the same
+    /// way agave does before taking a snapshot.
+    fn persist(bank: &Arc<Bank>) {
+        bank.freeze();
+        bank.squash();
+        bank.force_flush_accounts_cache();
+    }
+
+    fn assert_matches_get_program_accounts(bank: &Arc<Bank>, owners: &[Pubkey]) {
+        let scanned = scan_accounts_by_owner(bank, owners).unwrap();
+        for owner in owners {
+            assert_eq!(
+                pubkeys(&scanned[owner]),
+                pubkeys(&bank.get_program_accounts(owner).unwrap()),
+                "scan diverged from get_program_accounts for owner {owner}"
+            );
+            // The order the storages happen to be swept in must not reach the caller: downstream
+            // artifacts are diffed between runs of the same snapshot.
+            assert!(
+                scanned[owner].is_sorted_by_key(|(pubkey, _)| *pubkey),
+                "scan result for owner {owner} is not in a reproducible order"
+            );
+        }
     }
 
     #[test]
@@ -61,22 +183,14 @@ mod tests {
         let ignored_owner = Pubkey::new_unique();
         let store = |owner: &Pubkey, lamports: u64| {
             let pubkey = Pubkey::new_unique();
-            bank.store_account(
-                &pubkey,
-                &AccountSharedData::from(Account {
-                    lamports,
-                    data: vec![1, 2, 3],
-                    owner: *owner,
-                    executable: false,
-                    rent_epoch: 0,
-                }),
-            );
+            bank.store_account(&pubkey, &account(owner, lamports, vec![1, 2, 3]));
             pubkey
         };
 
         let first = [store(&wanted_owners[0], 10), store(&wanted_owners[0], 20)];
         let second = [store(&wanted_owners[1], 30)];
         store(&ignored_owner, 40);
+        persist(&bank);
 
         let scanned = scan_accounts_by_owner(&bank, &wanted_owners).unwrap();
 
@@ -84,17 +198,64 @@ mod tests {
         assert_eq!(pubkeys(&scanned[&wanted_owners[1]]), pubkeys_of(&second));
         assert!(!scanned.contains_key(&ignored_owner));
 
-        // the is_loadable() skip is not covered: a test bank drops zero-lamport accounts before the scan
-        for owner in &wanted_owners {
-            assert_eq!(
-                pubkeys(&scanned[owner]),
-                pubkeys(&bank.get_program_accounts(owner).unwrap()),
-                "single pass diverged from get_program_accounts for owner {owner}"
-            );
-        }
+        assert_matches_get_program_accounts(&bank, &wanted_owners);
     }
 
-    fn pubkeys_of(keys: &[Pubkey]) -> BTreeSet<Pubkey> {
-        keys.iter().copied().collect()
+    #[test]
+    fn stale_storage_versions_do_not_leak_into_the_result() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1_000_000);
+        // a child bank needs the fork graph that only BankForks installs
+        let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let wanted_owners = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let ignored_owner = Pubkey::new_unique();
+
+        // slot 0: every account starts out owned by a wanted owner
+        let rewritten = Pubkey::new_unique();
+        let reowned = Pubkey::new_unique();
+        let drained = Pubkey::new_unique();
+        let untouched = Pubkey::new_unique();
+        parent.store_account(&rewritten, &account(&wanted_owners[0], 10, vec![0; 4]));
+        parent.store_account(&reowned, &account(&wanted_owners[0], 20, vec![1; 4]));
+        parent.store_account(&drained, &account(&wanted_owners[1], 30, vec![2; 4]));
+        parent.store_account(&untouched, &account(&wanted_owners[1], 40, vec![3; 4]));
+        persist(&parent);
+
+        // slot 1: the same pubkeys get a second, newer version in a second storage
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            parent.clone(),
+            Default::default(),
+            1,
+        );
+        let added = Pubkey::new_unique();
+        bank.store_account(&rewritten, &account(&wanted_owners[0], 11, vec![9; 4]));
+        bank.store_account(&reowned, &account(&ignored_owner, 20, vec![1; 4]));
+        bank.store_account(&drained, &account(&wanted_owners[1], 0, vec![]));
+        bank.store_account(&added, &account(&wanted_owners[1], 50, vec![4; 4]));
+        persist(&bank);
+
+        let scanned = scan_accounts_by_owner(&bank, &wanted_owners).unwrap();
+
+        assert_eq!(
+            pubkeys(&scanned[&wanted_owners[0]]),
+            pubkeys_of(&[rewritten]),
+            "an account whose owner moved out of the wanted set must be dropped"
+        );
+        assert_eq!(
+            pubkeys(&scanned[&wanted_owners[1]]),
+            pubkeys_of(&[untouched, added]),
+            "a drained account must be dropped, an untouched one kept"
+        );
+
+        // the result must carry slot 1's bytes, not the stale slot 0 version phase 1 also saw
+        let (_, account) = scanned[&wanted_owners[0]]
+            .iter()
+            .find(|(pubkey, _)| *pubkey == rewritten)
+            .unwrap();
+        assert_eq!(account.lamports(), 11);
+        assert_eq!(account.data(), &[9; 4]);
+
+        assert_matches_get_program_accounts(&bank, &wanted_owners);
     }
 }

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -15,60 +15,42 @@ use {
     },
 };
 
-/// Collects every live account owned by one of `owners`, in two phases.
-///
-/// Phase 1 sweeps the snapshot storages in parallel and keeps only pubkeys, never account data.
-/// It yields a superset: a storage holds stale versions, and the same pubkey appears in every
-/// storage it was ever written to. Phase 2 re-loads each candidate through the accounts index,
-/// which is what narrows the superset down to exactly what `get_program_accounts` returns.
-///
-/// The alternative, `Bank::scan_all_accounts`, walks the index in pubkey order and does one
-/// random storage read per account, single threaded.
+// get_program_accounts is a full accounts-index scan per call, so one call per owner costs N passes
 pub fn scan_accounts_by_owner(
     bank: &Arc<Bank>,
     owners: &[Pubkey],
 ) -> anyhow::Result<HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>>> {
     let wanted: HashSet<Pubkey> = owners.iter().copied().collect();
 
-    // Accounts still in the write cache have no storage for phase 1 to find. Flushing first is
-    // agave's own pre-snapshot sequence; on a bank freshly loaded from a full snapshot the cache
-    // is empty and this costs nothing.
+    // accounts still in the write cache have no storage for the sweep to find
     bank.force_flush_accounts_cache();
 
     let sweep_started = Instant::now();
     let storages = bank.get_snapshot_storages(None);
-    let storage_count = storages.len();
     let candidates: HashSet<Pubkey> = storages
         .par_iter()
         .try_fold(HashSet::<Pubkey>::new, |mut candidates, storage| {
             storage
                 .accounts
                 .scan_accounts_without_data(|_offset, account| {
-                    // A live account is loadable, so a zero-lamport stored version is either
-                    // stale or a tombstone and can never be the one we end up keeping.
+                    // a live account is loadable, so a zero-lamport version is never the one kept
                     if account.lamports != 0 && wanted.contains(account.owner) {
                         candidates.insert(*account.pubkey);
                     }
                 })?;
             anyhow::Ok(candidates)
         })
-        .try_reduce(HashSet::new, |mut merged, mut other| {
-            if merged.len() < other.len() {
-                std::mem::swap(&mut merged, &mut other);
-            }
+        .try_reduce(HashSet::new, |mut merged, other| {
             merged.extend(other);
             anyhow::Ok(merged)
         })?;
-    // HashSet iteration order is randomised per process, and `collect` below preserves the input
-    // order, so without this the result vecs come out in a different order on every run of the
-    // same snapshot. Sorting restores the run-to-run reproducibility the index scan had, and
-    // groups the phase 2 lookups by accounts-index bin.
+    // HashSet order is randomised per process; sorting keeps the output reproducible run to run
     let mut candidates: Vec<Pubkey> = candidates.into_iter().collect();
     candidates.sort_unstable();
     info!(
         "Storage sweep: {} candidate pubkeys from {} storages in {:?}",
         candidates.len(),
-        storage_count,
+        storages.len(),
         sweep_started.elapsed()
     );
 
@@ -77,8 +59,7 @@ pub fn scan_accounts_by_owner(
     let confirmed: Vec<(Pubkey, AccountSharedData)> = candidates
         .par_iter()
         .filter_map(|pubkey| {
-            // What Bank::get_account does, minus filling the read-only cache: every candidate is
-            // touched exactly once here, so caching them would only evict useful entries.
+            // every candidate is loaded once, so caching it would only evict useful entries
             let (account, _slot) = accounts_db.load(
                 &bank.ancestors,
                 pubkey,
@@ -100,10 +81,10 @@ pub fn scan_accounts_by_owner(
     let mut collected: HashMap<Pubkey, Vec<(Pubkey, AccountSharedData)>> =
         wanted.iter().map(|owner| (*owner, Vec::new())).collect();
     for (pubkey, account) in confirmed {
-        let owner = *account.owner();
-        if let Some(accounts) = collected.get_mut(&owner) {
-            accounts.push((pubkey, account));
-        }
+        collected
+            .entry(*account.owner())
+            .or_default()
+            .push((pubkey, account));
     }
 
     for (owner, accounts) in &collected {
@@ -122,9 +103,6 @@ mod tests {
         std::collections::BTreeSet,
     };
 
-    /// Deliberately not a plain `collect`: a `BTreeSet` would swallow a repeated pubkey, and a
-    /// repeated pubkey is exactly what a broken phase 1 dedupe produces. Downstream that would
-    /// double count a stake account, so every comparison below has to reject it.
     fn pubkeys(accounts: &[(Pubkey, AccountSharedData)]) -> BTreeSet<Pubkey> {
         let pubkeys: BTreeSet<Pubkey> = accounts.iter().map(|(pubkey, _)| *pubkey).collect();
         assert_eq!(
@@ -149,8 +127,7 @@ mod tests {
         })
     }
 
-    /// Phase 1 only sees storages, so a test bank has to root and flush its write cache the same
-    /// way agave does before taking a snapshot.
+    // the sweep only sees storages, so a test bank has to root and flush its write cache
     fn persist(bank: &Arc<Bank>) {
         bank.freeze();
         bank.squash();
@@ -165,8 +142,6 @@ mod tests {
                 pubkeys(&bank.get_program_accounts(owner).unwrap()),
                 "scan diverged from get_program_accounts for owner {owner}"
             );
-            // The order the storages happen to be swept in must not reach the caller: downstream
-            // artifacts are diffed between runs of the same snapshot.
             assert!(
                 scanned[owner].is_sorted_by_key(|(pubkey, _)| *pubkey),
                 "scan result for owner {owner} is not in a reproducible order"
@@ -210,7 +185,7 @@ mod tests {
         let wanted_owners = [Pubkey::new_unique(), Pubkey::new_unique()];
         let ignored_owner = Pubkey::new_unique();
 
-        // slot 0: every account starts out owned by a wanted owner
+        // slot 0
         let rewritten = Pubkey::new_unique();
         let reowned = Pubkey::new_unique();
         let drained = Pubkey::new_unique();
@@ -221,7 +196,7 @@ mod tests {
         parent.store_account(&untouched, &account(&wanted_owners[1], 40, vec![3; 4]));
         persist(&parent);
 
-        // slot 1: the same pubkeys get a second, newer version in a second storage
+        // slot 1: newer versions of the same pubkeys land in a second storage
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             parent.clone(),
@@ -248,7 +223,6 @@ mod tests {
             "a drained account must be dropped, an untouched one kept"
         );
 
-        // the result must carry slot 1's bytes, not the stale slot 0 version phase 1 also saw
         let (_, account) = scanned[&wanted_owners[0]]
             .iter()
             .find(|(pubkey, _)| *pubkey == rewritten)

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -16,6 +16,8 @@ use {
 };
 
 // get_program_accounts is a full accounts-index scan per call, so one call per owner costs N passes
+// Correct only for a bank whose live accounts are all in storages (e.g. freshly snapshot-restored):
+// force_flush_accounts_cache flushes rooted slots only, so unrooted write-cache entries stay invisible
 pub fn scan_accounts_by_owner(
     bank: &Arc<Bank>,
     owners: &[Pubkey],

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -15,9 +15,14 @@ use {
     },
 };
 
-// get_program_accounts is a full accounts-index scan per call, so one call per owner costs N passes
-// Correct only for a bank whose live accounts are all in storages (e.g. freshly snapshot-restored):
-// force_flush_accounts_cache flushes rooted slots only, so unrooted write-cache entries stay invisible
+// Finds all accounts owned by the given programs in one pass over the storage files.
+// Doing this with get_program_accounts instead would rescan the whole accounts index
+// once per owner.
+//
+// Only use this on a bank loaded straight from a snapshot: there, every live account
+// is guaranteed to be in a storage file. On a bank that has processed transactions
+// since, recent writes may still sit in the write cache where this scan cannot see
+// them (the flush below covers rooted slots only).
 pub fn scan_accounts_by_owner(
     bank: &Arc<Bank>,
     owners: &[Pubkey],

--- a/snapshot-parser/src/account_scan.rs
+++ b/snapshot-parser/src/account_scan.rs
@@ -1,10 +1,7 @@
 use {
     log::info,
     rayon::prelude::*,
-    solana_accounts_db::{
-        accounts_db::{LoadHint, PopulateReadCache},
-        is_loadable::IsLoadable,
-    },
+    solana_accounts_db::accounts_db::{LoadHint, PopulateReadCache},
     solana_program::pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
@@ -22,7 +19,8 @@ use {
 // Only use this on a bank loaded straight from a snapshot: there, every live account
 // is guaranteed to be in a storage file. On a bank that has processed transactions
 // since, recent writes may still sit in the write cache where this scan cannot see
-// them (the flush below covers rooted slots only).
+// them (the flush below covers rooted slots only), so the scan errors out rather than
+// under-report.
 pub fn scan_accounts_by_owner(
     bank: &Arc<Bank>,
     owners: &[Pubkey],
@@ -31,6 +29,15 @@ pub fn scan_accounts_by_owner(
 
     // accounts still in the write cache have no storage for the sweep to find
     bank.force_flush_accounts_cache();
+    // the flush covers rooted slots only, and empties the cache of every slot it flushed.
+    // anything left is an unrooted write this scan would silently miss, so refuse to run.
+    let unflushed_slots = bank.rc.accounts.accounts_db.accounts_cache.num_slots();
+    anyhow::ensure!(
+        unflushed_slots == 0,
+        "account scan needs an empty write cache, but {unflushed_slots} slot(s) remain after \
+         flushing the rooted ones; scan a bank loaded straight from a snapshot, or root and \
+         flush the pending writes first"
+    );
 
     let sweep_started = Instant::now();
     let storages = bank.get_snapshot_storages(None);
@@ -47,7 +54,11 @@ pub fn scan_accounts_by_owner(
                 })?;
             anyhow::Ok(candidates)
         })
-        .try_reduce(HashSet::new, |mut merged, other| {
+        .try_reduce(HashSet::new, |mut merged, mut other| {
+            // extend the larger set with the smaller one, so the merge moves fewer entries
+            if other.len() > merged.len() {
+                std::mem::swap(&mut merged, &mut other);
+            }
             merged.extend(other);
             anyhow::Ok(merged)
         })?;
@@ -73,8 +84,9 @@ pub fn scan_accounts_by_owner(
                 LoadHint::Unspecified,
                 PopulateReadCache::False,
             )?;
-            // the same predicate get_program_accounts filters on, not a copy of it
-            (account.is_loadable() && wanted.contains(account.owner()))
+            // load() already drops zero-lamport accounts, so only the owner is left to check
+            wanted
+                .contains(account.owner())
                 .then_some((*pubkey, account))
         })
         .collect();
@@ -181,6 +193,38 @@ mod tests {
         assert!(!scanned.contains_key(&ignored_owner));
 
         assert_matches_get_program_accounts(&bank, &wanted_owners);
+    }
+
+    #[test]
+    fn unrooted_writes_fail_the_scan_instead_of_being_dropped() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1_000_000);
+        let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let wanted_owners = [Pubkey::new_unique()];
+        let persisted = Pubkey::new_unique();
+        parent.store_account(&persisted, &account(&wanted_owners[0], 10, vec![0; 4]));
+        persist(&parent);
+
+        // slot 1 is never squashed, so this write stays in the write cache: the rooted-only
+        // flush inside the scan cannot move it to a storage
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, parent, Default::default(), 1);
+        let unrooted = Pubkey::new_unique();
+        bank.store_account(&unrooted, &account(&wanted_owners[0], 20, vec![1; 4]));
+
+        // the account is live as far as the bank is concerned
+        assert_eq!(
+            pubkeys(&bank.get_program_accounts(&wanted_owners[0]).unwrap()),
+            pubkeys_of(&[persisted, unrooted])
+        );
+
+        // ...but the sweep would only find the persisted one, so the scan must refuse to answer
+        let err = scan_accounts_by_owner(&bank, &wanted_owners)
+            .expect_err("a scan that cannot see the write cache must not report a partial result");
+        assert!(
+            err.to_string().contains("empty write cache"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Bank load from snapshot is 5.5 min (parity with agave validator startup), but `bank.scan_all_accounts` walked all ~500M accounts single-threaded to find the ~6M we need, costing 56 min. On top of that, the process spent ~4 min after "Finished." unwinding accounts-db teardown.

## Change

- Two-phase scan: a rayon sweep over snapshot storages via `Bank::get_snapshot_storages` + `AccountsFile::scan_accounts_without_data` collects candidate pubkeys, then parallel `AccountsDb::load` confirms liveness. Public agave 4.1.0 API only; results deterministic (sorted).
- Exit right after outputs are flushed and synced (like agave's ledger-tool), skipping the teardown.
- Buildkite: the Stakes ETL trigger is now gated on `TEST_MODE` like the upload steps.

## Results

Epoch 1017, same snapshot, TEST_MODE builds vs production build [455](https://buildkite.com/marinade-finance/solana-snapshot-parser/builds/455) — details in [the test-results comment](https://github.com/marinade-finance/solana-snapshot-parser/pull/46#issuecomment-5330657685):

| Phase | Before (455) | After ([457](https://buildkite.com/marinade-finance/solana-snapshot-parser/builds/457)) |
|---|---|---|
| Account scan | 56 min | 4.6–27 s |
| Post-"Finished." teardown | ~4 min | none |
| Parse Snapshot job | 61.8 min | **6.5 min** |
| Whole build | ~66 min | ~10 min |

## Verification

- **Outputs byte-identical to production**: sha256 of all three artifacts (`stakes.json` 637 MB, `jito-stake-meta.json` 342 MB, `validators.json` 1.7 MB) matches build 455 exactly, in both PR test builds (456, 457).
- BigQuery epoch-1017 totals match exactly: row count and activated/activating/deactivating sums to the digit; candidate set deterministic across runs.
- Unit tests cover stale versions, owner changes, duplicates, ordering; `VERIFY_ACCOUNT_SCAN=true` env flag available for an in-process cross-check against `get_program_accounts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPCL5U99jygNNWAAknZHKQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Account scans now process snapshot storage in parallel, improving scanning speed for large snapshots.

* **Bug Fixes**
  * Improved detection of active accounts, including reowned, drained, stale, and recently updated accounts.
  * Scan results are now consistently sorted and deduplicated.
  * Scans now reject incomplete data instead of returning partial results.

* **Reliability**
  * The validator CLI now reliably flushes output and exits successfully after processing completes.
  * Snapshot testing workflows avoid triggering stake processing when running in test mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->