### PR TITLE
[GEN-8625] testnet parse: copy local snapshot instead of symlinking

### DIFF
--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -84,14 +84,14 @@ steps:
     - |
       mkdir -p $$WORKING_DIR
       snapshot_dir=$(mktemp --directory -p "$$WORKING_DIR" "snapshot-$$epoch-$(date +%s)-XXXXXX")
-      # Record the dir before copying so Cleanup can remove it even if the copy fails.
+      # Record the dir before copying so its path is in meta-data for manual cleanup if the copy fails (the plain wait before Cleanup stops the build on failure, so Cleanup won't auto-run).
       buildkite-agent meta-data set --redacted-vars="" snapshot_dir "$$snapshot_dir"
 
       local_snapshot=$(find $$local_snapshot_dir/*/$$epoch/ -name 'snapshot-*.tar.zst' 2>/dev/null | head -1)
       if [[ -n "$$local_snapshot" ]]; then
         echo "Found local snapshot at: $$local_snapshot"
-        # Copy (not symlink): unpacking the producer-owned testnet archive in place fails with EPERM; a copy into the agent-owned WORKING_DIR unpacks cleanly. -f overwrites a stale partial copy on retry.
-        if ! cp -f -- "$$local_snapshot" "$$snapshot_dir/"; then
+        # Copy (not symlink): unpacking the producer-owned testnet archive in place fails with EPERM; a copy into the agent-owned WORKING_DIR unpacks cleanly.
+        if ! cp -- "$$local_snapshot" "$$snapshot_dir/"; then
           echo "Failed to copy local snapshot" >&2
           exit 1
         fi

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -84,18 +84,22 @@ steps:
     - |
       mkdir -p $$WORKING_DIR
       snapshot_dir=$(mktemp --directory -p "$$WORKING_DIR" "snapshot-$$epoch-$(date +%s)-XXXXXX")
+      # Record the dir before copying so Cleanup can remove it even if the copy fails.
+      buildkite-agent meta-data set --redacted-vars="" snapshot_dir "$$snapshot_dir"
 
       local_snapshot=$(find $$local_snapshot_dir/*/$$epoch/ -name 'snapshot-*.tar.zst' 2>/dev/null | head -1)
       if [[ -n "$$local_snapshot" ]]; then
         echo "Found local snapshot at: $$local_snapshot"
         # Copy (not symlink): unpacking the producer-owned testnet archive in place fails with EPERM; a copy into the agent-owned WORKING_DIR unpacks cleanly. -f overwrites a stale partial copy on retry.
-        cp -f "$$local_snapshot" "$$snapshot_dir/"
+        if ! cp -f -- "$$local_snapshot" "$$snapshot_dir/"; then
+          echo "Failed to copy local snapshot" >&2
+          exit 1
+        fi
         buildkite-agent meta-data set --redacted-vars="" snapshot_local "true"
       else
         echo "No local snapshot found, using temp dir: $$snapshot_dir"
         buildkite-agent meta-data set --redacted-vars="" snapshot_local "false"
       fi
-      buildkite-agent meta-data set --redacted-vars="" snapshot_dir "$$snapshot_dir"
 
   - wait: ~
 

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -97,7 +97,7 @@ steps:
       local_snapshot=$(find $$local_snapshot_dir/*/$$epoch/ -name 'snapshot-*.tar.zst' 2>/dev/null | head -1)
       if [[ -n "$$local_snapshot" ]]; then
         echo "Found local snapshot at: $$local_snapshot"
-        # Copy (not symlink): unpacking the producer-owned testnet archive in place fails with EPERM; a copy into the agent-owned WORKING_DIR unpacks cleanly.
+        # Copy (not symlink): unpacking the local testnet archive via a symlink fails with EPERM (os error 1); a copy into the agent-owned WORKING_DIR unpacks cleanly.
         if ! cp -- "$$local_snapshot" "$$snapshot_dir/"; then
           echo "Failed to copy local snapshot" >&2
           exit 1

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -15,6 +15,13 @@ steps:
     concurrency_group: 'solana-snapshot-parser/fetch-and-parse-testnet'
     concurrency: 1
 
+  - label: "🧹 Cleanup"
+    commands:
+    # Reclaim leftover dirs from prior runs whose end Cleanup didn't run.
+    - |
+      mkdir -p "$$WORKING_DIR"
+      find "$$WORKING_DIR" -mindepth 1 -maxdepth 1 -type d -name 'snapshot-*' -exec rm -rf --preserve-root {} +
+
   - input: "Which epoch to fetch?"
     fields:
       - text: "Epoch"
@@ -84,7 +91,7 @@ steps:
     - |
       mkdir -p $$WORKING_DIR
       snapshot_dir=$(mktemp --directory -p "$$WORKING_DIR" "snapshot-$$epoch-$(date +%s)-XXXXXX")
-      # Record the dir before copying so its path is in meta-data for manual cleanup if the copy fails (the plain wait before Cleanup stops the build on failure, so Cleanup won't auto-run).
+      # Record the dir before copying so its path is in meta-data even if the copy fails.
       buildkite-agent meta-data set --redacted-vars="" snapshot_dir "$$snapshot_dir"
 
       local_snapshot=$(find $$local_snapshot_dir/*/$$epoch/ -name 'snapshot-*.tar.zst' 2>/dev/null | head -1)

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -88,7 +88,8 @@ steps:
       local_snapshot=$(find $$local_snapshot_dir/*/$$epoch/ -name 'snapshot-*.tar.zst' 2>/dev/null | head -1)
       if [[ -n "$$local_snapshot" ]]; then
         echo "Found local snapshot at: $$local_snapshot"
-        ln -s "$$local_snapshot" "$$snapshot_dir/"
+        # Copy (not symlink): unpacking the producer-owned testnet archive in place fails with EPERM; a copy into the agent-owned WORKING_DIR unpacks cleanly. -f overwrites a stale partial copy on retry.
+        cp -f "$$local_snapshot" "$$snapshot_dir/"
         buildkite-agent meta-data set --redacted-vars="" snapshot_local "true"
       else
         echo "No local snapshot found, using temp dir: $$snapshot_dir"


### PR DESCRIPTION
## Problem
Testnet parse fails at bank load:

```
Error: failed to load bank: Unpack error: Unpacking '/mnt/storage-1/snapshots-testnet/.../snapshot-429932255-....tar.zst' failed: IO error: Operation not permitted (os error 1)
```

## Cause
The Prepare step symlinks the source archive into the work dir and the CLI unpacks it in place:

```bash
ln -s "$local_snapshot" "$snapshot_dir/"
```

This is **identical to mainnet** (same `mktemp` under `WORKING_DIR`, same `/mnt/snapshots-storage` -> `/mnt/storage-1` mounts, same `ln -s`) — and mainnet works. The difference is ownership: testnet archives are written by a separate producer, whereas mainnet's generator runs as `buildkite-agent`. The agent can read the testnet file but unpacking the producer-owned archive in place hits `EPERM`.

## Fix
Copy into the agent-owned `WORKING_DIR` instead of symlinking:

```bash
cp -f "$local_snapshot" "$snapshot_dir/"
```

`-f` overwrites a stale partial copy on retry. Unpacks cleanly, removed by the existing Cleanup step; `Fetch snapshot` still skips the GCS fetch on `snapshot_local == "true"`. Mainnet keeps its symlink (source already agent-owned).

Costs one extra multi-GB copy into `/mnt/storage-1` per run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when preparing local snapshots.
  * Automatically removes leftover snapshot directories before a new preparation attempt.
  * Detects and reports snapshot copy failures instead of continuing silently.
  * Improved handling of snapshot metadata and symlink-related copy issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->