### PR TITLE
[GEN-8749] Require jito-stake-meta on mainnet and name the upload by Jito program hash

### DIFF
--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -133,7 +133,7 @@ steps:
     artifact_paths:
         - ./validators.json
         - ./stakes.json
-        - ./jito-stake-meta-*.json
+        - ./jito-stake-meta.json
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -151,13 +151,10 @@ steps:
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
-      shopt -s nullglob
-      jito_stake_meta=(./jito-stake-meta-*.json)
-      shopt -u nullglob
-      if [[ $${#jito_stake_meta[@]} -eq 1 ]]; then
-        cp "$${jito_stake_meta[0]}" "$$snapshot_dir/"
+      if [[ -f ./jito-stake-meta.json ]]; then
+        cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
       else
-        echo "Expected one ./jito-stake-meta-<hash>.json, found $${#jito_stake_meta[@]}!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
+        echo "Jito stake meta collection was not produced!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
       fi
 
   - wait: ~
@@ -178,13 +175,10 @@ steps:
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - |
-      shopt -s nullglob
-      jito_stake_meta=("$$snapshot_dir"/jito-stake-meta-*.json)
-      shopt -u nullglob
-      if [[ $${#jito_stake_meta[@]} -eq 1 ]]; then
-        gcloud storage cp "$${jito_stake_meta[0]}" "$GCLOUD_SNAPSHOTS/$$epoch/"
+      if [[ -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
+        gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
       else
-        echo "Expected one $$snapshot_dir/jito-stake-meta-<hash>.json, found $${#jito_stake_meta[@]}!"
+        echo "Jito stake meta collection was not produced!"
       fi
 
   - wait: ~

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -133,7 +133,7 @@ steps:
     artifact_paths:
         - ./validators.json
         - ./stakes.json
-        - ./jito-stake-meta.json
+        - ./jito-stake-meta-*.json
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -151,10 +151,13 @@ steps:
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
-      if [[ -f ./jito-stake-meta.json ]]; then
-        cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
+      shopt -s nullglob
+      jito_stake_meta=(./jito-stake-meta-*.json)
+      shopt -u nullglob
+      if [[ $${#jito_stake_meta[@]} -eq 1 ]]; then
+        cp "$${jito_stake_meta[0]}" "$$snapshot_dir/"
       else
-        echo "Jito stake meta collection was not produced!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
+        echo "Expected one ./jito-stake-meta-<hash>.json, found $${#jito_stake_meta[@]}!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
       fi
 
   - wait: ~
@@ -175,10 +178,13 @@ steps:
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - |
-      if [[ -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
-        gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+      shopt -s nullglob
+      jito_stake_meta=("$$snapshot_dir"/jito-stake-meta-*.json)
+      shopt -u nullglob
+      if [[ $${#jito_stake_meta[@]} -eq 1 ]]; then
+        gcloud storage cp "$${jito_stake_meta[0]}" "$GCLOUD_SNAPSHOTS/$$epoch/"
       else
-        echo "Jito stake meta collection was not produced!"
+        echo "Expected one $$snapshot_dir/jito-stake-meta-<hash>.json, found $${#jito_stake_meta[@]}!"
       fi
 
   - wait: ~

--- a/.buildkite/snapshot-fetch-and-parse-testnet.yml
+++ b/.buildkite/snapshot-fetch-and-parse-testnet.yml
@@ -146,7 +146,8 @@ steps:
         --output-jito-stake-meta "./jito-stake-meta.json" \
         --tip-distribution-program "DzvGET57TAgEDxvm3ERUM4GNcsAJdqjDLCne9sdfY4wf" \
         --tip-payment-program "GJHtFqM9agxPmkeKjHny6qiRKrXZALvvFGiKf11QE7hy" \
-        --require-priority-fee-data false
+        --require-priority-fee-data false \
+        --require-jito-stake-meta false
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -150,7 +150,6 @@ steps:
       cp ./stakes.json "$$snapshot_dir/stakes.json"
       if [[ -f ./jito-stake-meta.json && -f ./jito-stake-meta.json.program-hash ]]; then
         cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
-        # Names the uploaded object, so it travels with the collection
         cp ./jito-stake-meta.json.program-hash "$$snapshot_dir/jito-stake-meta.json.program-hash"
       else
         echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
@@ -179,8 +178,7 @@ steps:
         exit 1
       fi
       jito_program_hash=$(cat "$$snapshot_dir/jito-stake-meta.json.program-hash")
-      # The stakes ETL looks the object up by this name; a malformed hash would make it
-      # silently fall back to Jito's bucket for every epoch from now on
+      # The stakes ETL looks the object up by this name and silently skips a malformed one
       if [[ ! "$$jito_program_hash" =~ ^[0-9a-f]{16}$$ ]]; then
         echo "Jito program hash '$$jito_program_hash' is not 16 lowercase hex characters, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -177,7 +177,7 @@ steps:
         exit 1
       fi
       jito_program_hash=$(buildkite-agent meta-data get jito_program_hash)
-      # The stakes ETL looks the object up by this name and silently skips a malformed one
+      # The stakes ETL looks the object up by this name
       if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
         echo "Jito program hash '$$jito_program_hash' is not a pair of dot-joined cksum CRC-32 decimals, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -147,26 +147,12 @@ steps:
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
-      shopt -s nullglob
-      jito_stake_meta=(./jito-stake-meta-*.json)
-      shopt -u nullglob
-      if [[ $${#jito_stake_meta[@]} -eq 0 ]]; then
-        echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
+      if ! jito_stake_meta_name=$(./scripts/find-jito-stake-meta.bash .); then
+        echo "No single, validly named Jito stake meta collection was produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
-      if [[ $${#jito_stake_meta[@]} -gt 1 ]]; then
-        echo "Several Jito stake meta collections found ($${jito_stake_meta[*]}), refusing to guess which one this build produced!" | buildkite-agent annotate --style error --context "jito-stake-meta"
-        exit 1
-      fi
-      jito_stake_meta_name=$(basename "$${jito_stake_meta[0]}")
-      jito_program_hash=$${jito_stake_meta_name#jito-stake-meta-}
-      jito_program_hash=$${jito_program_hash%.json}
-      # The stakes ETL looks the object up by this name
-      if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
-        echo "Jito stake meta collection '$$jito_stake_meta_name' is not named by a pair of dot-joined cksum CRC-32 decimals!" | buildkite-agent annotate --style error --context "jito-stake-meta"
-        exit 1
-      fi
-      cp "$${jito_stake_meta[0]}" "$$snapshot_dir/$$jito_stake_meta_name"
+      rm -f "$$snapshot_dir"/jito-stake-meta-*.json
+      cp "./$$jito_stake_meta_name" "$$snapshot_dir/$$jito_stake_meta_name"
 
   - wait: ~
 
@@ -185,28 +171,13 @@ steps:
     - epoch=$(buildkite-agent meta-data get epoch)
     # Checked before the first upload, so a failing epoch leaves no partial data in GCS
     - |
-      shopt -s nullglob
-      jito_stake_meta=("$$snapshot_dir"/jito-stake-meta-*.json)
-      shopt -u nullglob
-      if [[ $${#jito_stake_meta[@]} -eq 0 ]]; then
-        echo "Jito stake meta collection was not produced, nothing to upload for the stakes ETL!" | buildkite-agent annotate --style error --context "jito-stake-meta"
-        exit 1
-      fi
-      if [[ $${#jito_stake_meta[@]} -gt 1 ]]; then
-        echo "Several Jito stake meta collections found ($${jito_stake_meta[*]}), refusing to guess which one to upload!" | buildkite-agent annotate --style error --context "jito-stake-meta"
-        exit 1
-      fi
-      jito_stake_meta_name=$(basename "$${jito_stake_meta[0]}")
-      jito_program_hash=$${jito_stake_meta_name#jito-stake-meta-}
-      jito_program_hash=$${jito_program_hash%.json}
-      # The stakes ETL looks the object up by this name
-      if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
-        echo "Jito stake meta collection '$$jito_stake_meta_name' is not named by a pair of dot-joined cksum CRC-32 decimals, refusing to upload it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+      if ! jito_stake_meta_name=$(./scripts/find-jito-stake-meta.bash "$$snapshot_dir"); then
+        echo "No single, validly named Jito stake meta collection to upload for the stakes ETL, see the job log above." | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
-    - gcloud storage cp "$${jito_stake_meta[0]}" "$GCLOUD_SNAPSHOTS/$$epoch/$$jito_stake_meta_name"
+    - gcloud storage cp "$$snapshot_dir/$$jito_stake_meta_name" "$GCLOUD_SNAPSHOTS/$$epoch/$$jito_stake_meta_name"
 
   - wait: ~
 

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -133,6 +133,7 @@ steps:
         - ./validators.json
         - ./stakes.json
         - ./jito-stake-meta.json
+        - ./jito-stake-meta.json.program-hash
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -147,8 +148,10 @@ steps:
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
-      if [[ -f ./jito-stake-meta.json ]]; then
+      if [[ -f ./jito-stake-meta.json && -f ./jito-stake-meta.json.program-hash ]]; then
         cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
+        # Names the uploaded object, so it travels with the collection
+        cp ./jito-stake-meta.json.program-hash "$$snapshot_dir/jito-stake-meta.json.program-hash"
       else
         echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
@@ -169,15 +172,22 @@ steps:
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - epoch=$(buildkite-agent meta-data get epoch)
-    - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
-    - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+    # Checked before the first upload, so a failing epoch leaves no partial data in GCS
     - |
-      if [[ -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
-        gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
-      else
+      if [[ ! -f "$$snapshot_dir/jito-stake-meta.json" || ! -f "$$snapshot_dir/jito-stake-meta.json.program-hash" ]]; then
         echo "Jito stake meta collection was not produced, nothing to upload for the stakes ETL!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
+      jito_program_hash=$(cat "$$snapshot_dir/jito-stake-meta.json.program-hash")
+      # The stakes ETL looks the object up by this name; a malformed hash would make it
+      # silently fall back to Jito's bucket for every epoch from now on
+      if [[ ! "$$jito_program_hash" =~ ^[0-9a-f]{16}$$ ]]; then
+        echo "Jito program hash '$$jito_program_hash' is not 16 lowercase hex characters, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
+      fi
+    - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+    - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
+    - gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/jito-stake-meta-$$jito_program_hash.json"
 
   - wait: ~
 

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -133,7 +133,6 @@ steps:
         - ./validators.json
         - ./stakes.json
         - ./jito-stake-meta.json
-        - ./jito-stake-meta.json.program-hash
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -150,7 +149,7 @@ steps:
       cp ./stakes.json "$$snapshot_dir/stakes.json"
       if [[ -f ./jito-stake-meta.json && -f ./jito-stake-meta.json.program-hash ]]; then
         cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
-        cp ./jito-stake-meta.json.program-hash "$$snapshot_dir/jito-stake-meta.json.program-hash"
+        buildkite-agent meta-data set --redacted-vars='' jito_program_hash "$(cat ./jito-stake-meta.json.program-hash)"
       else
         echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
@@ -173,11 +172,11 @@ steps:
     - epoch=$(buildkite-agent meta-data get epoch)
     # Checked before the first upload, so a failing epoch leaves no partial data in GCS
     - |
-      if [[ ! -f "$$snapshot_dir/jito-stake-meta.json" || ! -f "$$snapshot_dir/jito-stake-meta.json.program-hash" ]]; then
+      if [[ ! -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
         echo "Jito stake meta collection was not produced, nothing to upload for the stakes ETL!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
-      jito_program_hash=$(cat "$$snapshot_dir/jito-stake-meta.json.program-hash")
+      jito_program_hash=$(buildkite-agent meta-data get jito_program_hash)
       # The stakes ETL looks the object up by this name and silently skips a malformed one
       if [[ ! "$$jito_program_hash" =~ ^[0-9a-f]{16}$$ ]]; then
         echo "Jito program hash '$$jito_program_hash' is not 16 lowercase hex characters, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -142,14 +142,16 @@ steps:
         --ledger-path "$$snapshot_dir" \
         --output-validator-meta-collection "./validators.json" \
         --output-stake-meta-collection "./stakes.json" \
-        --output-jito-stake-meta "./jito-stake-meta.json"
+        --output-jito-stake-meta "./jito-stake-meta.json" \
+        --require-jito-stake-meta true
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
       if [[ -f ./jito-stake-meta.json ]]; then
         cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
       else
-        echo "Jito stake meta collection was not produced!" | buildkite-agent annotate --style warning --context "jito-stake-meta"
+        echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
       fi
 
   - wait: ~
@@ -173,7 +175,8 @@ steps:
       if [[ -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
         gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
       else
-        echo "Jito stake meta collection was not produced!"
+        echo "Jito stake meta collection was not produced, nothing to upload for the stakes ETL!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
       fi
 
   - wait: ~

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -132,7 +132,7 @@ steps:
     artifact_paths:
         - ./validators.json
         - ./stakes.json
-        - ./jito-stake-meta.json
+        - ./jito-stake-meta-*.json
     commands:
     - snapshot_dir=$(buildkite-agent meta-data get snapshot_dir)
     - buildkite-agent artifact download --include-retried-jobs target/release/snapshot-parser-validator-cli .
@@ -147,13 +147,26 @@ steps:
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"
       cp ./stakes.json "$$snapshot_dir/stakes.json"
-      if [[ -f ./jito-stake-meta.json && -f ./jito-stake-meta.json.program-hash ]]; then
-        cp ./jito-stake-meta.json "$$snapshot_dir/jito-stake-meta.json"
-        buildkite-agent meta-data set --redacted-vars='' jito_program_hash "$(cat ./jito-stake-meta.json.program-hash)"
-      else
+      shopt -s nullglob
+      jito_stake_meta=(./jito-stake-meta-*.json)
+      shopt -u nullglob
+      if [[ $${#jito_stake_meta[@]} -eq 0 ]]; then
         echo "Jito stake meta collection was not produced! The stakes ETL consumes this file, see the parser output above." | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
+      if [[ $${#jito_stake_meta[@]} -gt 1 ]]; then
+        echo "Several Jito stake meta collections found ($${jito_stake_meta[*]}), refusing to guess which one this build produced!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
+      fi
+      jito_stake_meta_name=$(basename "$${jito_stake_meta[0]}")
+      jito_program_hash=$${jito_stake_meta_name#jito-stake-meta-}
+      jito_program_hash=$${jito_program_hash%.json}
+      # The stakes ETL looks the object up by this name
+      if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
+        echo "Jito stake meta collection '$$jito_stake_meta_name' is not named by a pair of dot-joined cksum CRC-32 decimals!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
+      fi
+      cp "$${jito_stake_meta[0]}" "$$snapshot_dir/$$jito_stake_meta_name"
 
   - wait: ~
 
@@ -172,19 +185,28 @@ steps:
     - epoch=$(buildkite-agent meta-data get epoch)
     # Checked before the first upload, so a failing epoch leaves no partial data in GCS
     - |
-      if [[ ! -f "$$snapshot_dir/jito-stake-meta.json" ]]; then
+      shopt -s nullglob
+      jito_stake_meta=("$$snapshot_dir"/jito-stake-meta-*.json)
+      shopt -u nullglob
+      if [[ $${#jito_stake_meta[@]} -eq 0 ]]; then
         echo "Jito stake meta collection was not produced, nothing to upload for the stakes ETL!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
-      jito_program_hash=$(buildkite-agent meta-data get jito_program_hash)
+      if [[ $${#jito_stake_meta[@]} -gt 1 ]]; then
+        echo "Several Jito stake meta collections found ($${jito_stake_meta[*]}), refusing to guess which one to upload!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        exit 1
+      fi
+      jito_stake_meta_name=$(basename "$${jito_stake_meta[0]}")
+      jito_program_hash=$${jito_stake_meta_name#jito-stake-meta-}
+      jito_program_hash=$${jito_program_hash%.json}
       # The stakes ETL looks the object up by this name
       if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
-        echo "Jito program hash '$$jito_program_hash' is not a pair of dot-joined cksum CRC-32 decimals, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+        echo "Jito stake meta collection '$$jito_stake_meta_name' is not named by a pair of dot-joined cksum CRC-32 decimals, refusing to upload it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
     - gcloud storage cp "$$snapshot_dir/stakes.json" "$GCLOUD_SNAPSHOTS/$$epoch/"
-    - gcloud storage cp "$$snapshot_dir/jito-stake-meta.json" "$GCLOUD_SNAPSHOTS/$$epoch/jito-stake-meta-$$jito_program_hash.json"
+    - gcloud storage cp "$${jito_stake_meta[0]}" "$GCLOUD_SNAPSHOTS/$$epoch/$$jito_stake_meta_name"
 
   - wait: ~
 

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -142,7 +142,7 @@ steps:
         --ledger-path "$$snapshot_dir" \
         --output-validator-meta-collection "./validators.json" \
         --output-stake-meta-collection "./stakes.json" \
-        --output-jito-stake-meta "./jito-stake-meta.json" \
+        --output-jito-stake-meta "./jito-stake-meta-{hash}.json" \
         --require-jito-stake-meta true
     - |
       cp ./validators.json "$$snapshot_dir/validators.json"

--- a/.buildkite/snapshot-fetch-and-parse.yml
+++ b/.buildkite/snapshot-fetch-and-parse.yml
@@ -178,8 +178,8 @@ steps:
       fi
       jito_program_hash=$(buildkite-agent meta-data get jito_program_hash)
       # The stakes ETL looks the object up by this name and silently skips a malformed one
-      if [[ ! "$$jito_program_hash" =~ ^[0-9a-f]{16}$$ ]]; then
-        echo "Jito program hash '$$jito_program_hash' is not 16 lowercase hex characters, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
+      if [[ ! "$$jito_program_hash" =~ ^[0-9]{1,10}\.[0-9]{1,10}$$ ]]; then
+        echo "Jito program hash '$$jito_program_hash' is not a pair of dot-joined cksum CRC-32 decimals, refusing to name the uploaded stake meta by it!" | buildkite-agent annotate --style error --context "jito-stake-meta"
         exit 1
       fi
     - gcloud storage cp "$$snapshot_dir/validators.json" "$GCLOUD_SNAPSHOTS/$$epoch/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,6 +5329,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "crc",
  "env_logger",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5320,6 +5320,7 @@ dependencies = [
  "serde_json",
  "snapshot-parser",
  "solana-accounts-db",
+ "solana-loader-v3-interface 7.0.0",
  "solana-program 4.0.0",
  "solana-runtime",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.22.1"
 bs58 = "0.5.1"
 bincode = "1.3.3"
 clap = { version = "4.1.11", features = ["derive", "env"] }
+crc = "3.4.0"
 env_logger = "0.11.10"
 indicatif = { version = "0.18.4"}
 log = "0.4.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ snapshot-parser = { path = "./snapshot-parser" }
 agave-snapshots = "=4.1.0"
 solana-genesis-utils = "=4.1.0"
 solana-ledger = { version = "=4.1.0", features = ["agave-unstable-api"] }
+solana-loader-v3-interface = { version = "=7.0.0", features = ["serde"] }
 solana-native-token = "=3.0.0"
 solana-program = "=4.0.0"
 solana-runtime = "=4.1.0"

--- a/scripts/find-jito-stake-meta.bash
+++ b/scripts/find-jito-stake-meta.bash
@@ -37,9 +37,12 @@ name=$(basename "${found[0]}")
 program_hash=${name#jito-stake-meta-}
 program_hash=${program_hash%.json}
 
-if [[ ! $program_hash =~ ^[0-9]{1,10}\.[0-9]{1,10}$ ]]
+crc32_max=4294967295
+
+if [[ ! $program_hash =~ ^(0|[1-9][0-9]{0,9})\.(0|[1-9][0-9]{0,9})$ ]] \
+    || (( 10#${BASH_REMATCH[1]} > crc32_max || 10#${BASH_REMATCH[2]} > crc32_max ))
 then
-    echo "Jito stake meta collection '$name' is not named by a pair of dot-joined cksum CRC-32 decimals, which is the name the stakes ETL looks the object up by!" >&2
+    echo "Jito stake meta collection '$name' is not named by a pair of dot-joined canonical cksum CRC-32 decimals (no leading zeros, each at most $crc32_max), which is the name the stakes ETL looks the object up by!" >&2
     exit 1
 fi
 

--- a/scripts/find-jito-stake-meta.bash
+++ b/scripts/find-jito-stake-meta.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+search_dir="$1"
+
+if [[ -z $search_dir ]]
+then
+    echo "Usage: $0 <search-dir>" >&2
+    exit 1
+fi
+
+if ! [[ -d $search_dir ]]
+then
+    echo "Search directory ($search_dir) does not exist." >&2
+    exit 1
+fi
+
+shopt -s nullglob
+found=("$search_dir"/jito-stake-meta-*.json)
+shopt -u nullglob
+
+if [[ ${#found[@]} -eq 0 ]]
+then
+    echo "No Jito stake meta collection found in $search_dir!" >&2
+    exit 1
+fi
+
+if [[ ${#found[@]} -gt 1 ]]
+then
+    echo "Several Jito stake meta collections found in $search_dir (${found[*]}), refusing to guess which one to use!" >&2
+    exit 1
+fi
+
+name=$(basename "${found[0]}")
+program_hash=${name#jito-stake-meta-}
+program_hash=${program_hash%.json}
+
+if [[ ! $program_hash =~ ^[0-9]{1,10}\.[0-9]{1,10}$ ]]
+then
+    echo "Jito stake meta collection '$name' is not named by a pair of dot-joined cksum CRC-32 decimals, which is the name the stakes ETL looks the object up by!" >&2
+    exit 1
+fi
+
+echo "$name"

--- a/snapshot-parser-validator-cli/Cargo.toml
+++ b/snapshot-parser-validator-cli/Cargo.toml
@@ -13,6 +13,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 bincode = { workspace = true }
 clap = { workspace = true }
+crc = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }

--- a/snapshot-parser-validator-cli/Cargo.toml
+++ b/snapshot-parser-validator-cli/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 snapshot-parser = { workspace = true }
+solana-loader-v3-interface = { workspace = true }
 solana-runtime = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -13,7 +13,7 @@ use {
     log::{error, info},
     snapshot_parser::bank_loader::create_bank_from_ledger,
     snapshot_parser::cli::path_parser,
-    std::path::{Path, PathBuf},
+    std::path::PathBuf,
 };
 
 #[derive(Parser, Debug)]
@@ -31,8 +31,7 @@ struct Args {
     #[arg(long, env)]
     output_stake_meta_collection: String,
 
-    /// Base path for the Jito-format stake metas; the Jito program hash goes before the
-    /// extension (e.g., jito-stake-meta.json is written as jito-stake-meta-<hash>.json)
+    /// Path to write JSON file to for the Jito-format stake metas; a literal {hash} in it is replaced by the Jito program hash (e.g., jito-stake-meta-{hash}.json)
     #[arg(long, env)]
     output_jito_stake_meta: Option<String>,
 
@@ -68,17 +67,10 @@ impl Args {
     }
 }
 
-fn hash_named_path(output_jito_stake_meta: &str, jito_program_hash: &str) -> String {
-    let path = Path::new(output_jito_stake_meta);
-    let stem = path.file_stem().unwrap_or_default().to_string_lossy();
-    let file_name = match path.extension() {
-        Some(extension) => format!("{stem}-{jito_program_hash}.{}", extension.to_string_lossy()),
-        None => format!("{stem}-{jito_program_hash}"),
-    };
+const JITO_PROGRAM_HASH_PLACEHOLDER: &str = "{hash}";
 
-    path.with_file_name(file_name)
-        .to_string_lossy()
-        .into_owned()
+fn resolve_output_path(output_jito_stake_meta: &str, jito_program_hash: &str) -> String {
+    output_jito_stake_meta.replace(JITO_PROGRAM_HASH_PLACEHOLDER, jito_program_hash)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -170,11 +162,13 @@ fn main() -> anyhow::Result<()> {
                         tip_payment_program,
                         require_priority_fee_data,
                     )?;
-                let hash_named_output =
-                    hash_named_path(&output_path, &jito_stake_meta_collection.jito_program_hash);
+                let resolved_output = resolve_output_path(
+                    &output_path,
+                    &jito_stake_meta_collection.jito_program_hash,
+                );
                 // Jito publishes this collection pretty-printed
-                write_to_json_file(&jito_stake_meta_collection, &hash_named_output)?;
-                info!("Jito stake meta collection finished, written to {hash_named_output}.");
+                write_to_json_file(&jito_stake_meta_collection, &resolved_output)?;
+                info!("Jito stake meta collection finished, written to {resolved_output}.");
                 Ok(())
             };
 
@@ -234,6 +228,24 @@ mod tests {
     use snapshot_parser::utils::read_from_json_file;
     use snapshot_parser_validator_cli::jito_stake_meta::JitoStakeMetaCollection;
     use std::fs;
+    use std::path::Path;
+
+    const HASH: &str = "2426260379.1775319386";
+
+    fn matches_pipeline_glob_and_guard(path: &str) -> bool {
+        let Some(hash) = path
+            .strip_prefix("./jito-stake-meta-")
+            .and_then(|name| name.strip_suffix(".json"))
+        else {
+            return false;
+        };
+        let Some((left, right)) = hash.split_once('.') else {
+            return false;
+        };
+        [left, right].iter().all(|part| {
+            (1..=10).contains(&part.len()) && part.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    }
 
     // Replays the testnet Parse step's exact argv so the CLI contract is checked
     // without a snapshot download; would have caught --require-priority-fee-data
@@ -278,9 +290,9 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(
-            hash_named_path(&args.output_jito_stake_meta.unwrap(), HASH),
-            "./jito-stake-meta-2426260379.1775319386.json",
-            "the Parse step globs ./jito-stake-meta-*.json for exactly this name"
+            resolve_output_path(&args.output_jito_stake_meta.unwrap(), HASH),
+            "./jito-stake-meta.json",
+            "the testnet Parse step copies and uploads exactly this name"
         );
     }
 
@@ -344,41 +356,28 @@ mod tests {
         assert!(!args.require_jito_stake_meta);
     }
 
-    const HASH: &str = "2426260379.1775319386";
-
     #[test]
-    fn the_hash_goes_before_the_extension() {
+    fn the_placeholder_is_substituted_wherever_it_stands() {
         assert_eq!(
-            hash_named_path("./jito-stake-meta.json", HASH),
+            resolve_output_path("./jito-stake-meta-{hash}.json", HASH),
             "./jito-stake-meta-2426260379.1775319386.json"
         );
         assert_eq!(
-            hash_named_path("jito-stake-meta.json", HASH),
-            "jito-stake-meta-2426260379.1775319386.json"
+            resolve_output_path("/mnt/out/{hash}/jito-stake-meta.json", HASH),
+            "/mnt/out/2426260379.1775319386/jito-stake-meta.json"
         );
-        assert_eq!(
-            hash_named_path("/mnt/out/jito-stake-meta.json", HASH),
-            "/mnt/out/jito-stake-meta-2426260379.1775319386.json"
-        );
+        assert_eq!(resolve_output_path("{hash}", HASH), "2426260379.1775319386");
     }
 
     #[test]
-    fn a_dotted_name_splits_at_the_last_extension() {
+    fn a_value_without_the_placeholder_is_the_path_written() {
         assert_eq!(
-            hash_named_path("./jito.stake.meta.json", HASH),
-            "./jito.stake.meta-2426260379.1775319386.json"
-        );
-    }
-
-    #[test]
-    fn a_path_without_an_extension_gets_the_hash_appended() {
-        assert_eq!(
-            hash_named_path("./jito-stake-meta", HASH),
-            "./jito-stake-meta-2426260379.1775319386"
+            resolve_output_path("./jito-stake-meta.json", HASH),
+            "./jito-stake-meta.json"
         );
         assert_eq!(
-            hash_named_path("/mnt/out/jito-stake-meta", HASH),
-            "/mnt/out/jito-stake-meta-2426260379.1775319386"
+            resolve_output_path("/mnt/out/jito-stake-meta", HASH),
+            "/mnt/out/jito-stake-meta"
         );
     }
 
@@ -400,8 +399,8 @@ mod tests {
             jito_program_hash: HASH.to_string(),
         };
 
-        let out = hash_named_path(
-            &dir.join("jito-stake-meta.json").to_string_lossy(),
+        let out = resolve_output_path(
+            &dir.join("jito-stake-meta-{hash}.json").to_string_lossy(),
             &collection.jito_program_hash,
         );
         write_to_json_file(&collection, &out).unwrap();
@@ -427,7 +426,7 @@ mod tests {
             "--output-stake-meta-collection",
             "./stakes.json",
             "--output-jito-stake-meta",
-            "./jito-stake-meta.json",
+            "./jito-stake-meta-{hash}.json",
             "--require-jito-stake-meta",
             "true",
         ])
@@ -437,10 +436,11 @@ mod tests {
 
         assert!(args.require_jito_stake_meta);
         assert!(args.require_priority_fee_data);
-        assert_eq!(
-            hash_named_path(&args.output_jito_stake_meta.unwrap(), HASH),
-            "./jito-stake-meta-2426260379.1775319386.json",
-            "the Parse step globs ./jito-stake-meta-*.json for exactly this name"
+        let out = resolve_output_path(&args.output_jito_stake_meta.unwrap(), HASH);
+        assert_eq!(out, "./jito-stake-meta-2426260379.1775319386.json");
+        assert!(
+            matches_pipeline_glob_and_guard(&out),
+            "the Parse step globs ./jito-stake-meta-*.json and guards the name: {out}"
         );
     }
 }

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -61,7 +61,6 @@ struct Args {
 }
 
 impl Args {
-    /// Rejects flag combinations that would silently do nothing at runtime
     fn validate(&self) -> anyhow::Result<()> {
         if self.require_jito_stake_meta && self.output_jito_stake_meta.is_none() {
             anyhow::bail!("--require-jito-stake-meta true needs --output-jito-stake-meta, otherwise the required collection is never produced");
@@ -71,8 +70,7 @@ impl Args {
     }
 }
 
-/// The pipeline names the uploaded collection by this hash, so it must not read 342MB
-/// of JSON to find it
+// A side file so the pipeline can name the upload without reading the collection JSON
 fn program_hash_path(output_jito_stake_meta: &str) -> String {
     format!("{output_jito_stake_meta}.program-hash")
 }
@@ -173,8 +171,6 @@ fn main() -> anyhow::Result<()> {
                 let short_hash = program_hash
                     .get(..PROGRAM_HASH_SHORT_LEN)
                     .ok_or_else(|| anyhow::anyhow!("Malformed Jito program hash {program_hash}"))?;
-                // The upload step names the GCS object by this hash, so it lands next to
-                // the collection instead of being dug out of the JSON
                 write_to_text_file(&format!("{short_hash}\n"), &program_hash_path(&output_path))?;
                 info!(
                     "Jito stake meta collection finished, Jito program hash: {program_hash} (short: {short_hash})."
@@ -204,8 +200,7 @@ fn main() -> anyhow::Result<()> {
         failure = failure.or(Some(outcome));
     }
 
-    // Fatal only where the collection is consumed downstream; elsewhere it stays a
-    // best-effort backup of what Jito publishes itself and must not fail the parsing
+    // A best-effort backup of what Jito publishes itself, unless a cluster's ETL consumes it
     if let Some(handle) = jito_stake_meta_collection_handle {
         let outcome = match handle.join() {
             Ok(Ok(())) => {
@@ -267,7 +262,6 @@ mod tests {
             .expect("testnet Parse step argv must be valid");
 
         assert!(!args.require_priority_fee_data);
-        // Testnet must keep producing the Jito collection best-effort
         assert!(!args.require_jito_stake_meta);
         assert_eq!(
             args.tip_distribution_program,
@@ -301,8 +295,6 @@ mod tests {
         assert!(!args.require_jito_stake_meta);
     }
 
-    // A required collection with nowhere to write it is a configuration mistake that
-    // would otherwise pass the build without ever producing the file the ETL waits for.
     #[test]
     fn require_jito_stake_meta_without_an_output_is_rejected() {
         let args = Args::try_parse_from([
@@ -327,7 +319,6 @@ mod tests {
         );
     }
 
-    // Explicitly not requiring the collection stays valid without an output path
     #[test]
     fn not_requiring_jito_stake_meta_without_an_output_is_allowed() {
         let args = Args::try_parse_from([
@@ -346,7 +337,6 @@ mod tests {
         assert!(!args.require_jito_stake_meta);
     }
 
-    // The pipeline reads this path to name the uploaded GCS object
     #[test]
     fn program_hash_side_file_sits_next_to_the_collection() {
         assert_eq!(
@@ -355,8 +345,7 @@ mod tests {
         );
     }
 
-    // Replays the mainnet Parse step's argv: the Jito collection is mandatory there,
-    // its absence would stall the stakes ETL.
+    // Replays the mainnet Parse step's exact argv
     #[test]
     fn parses_mainnet_parse_step_argv() {
         let args = Args::try_parse_from([

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -1,8 +1,9 @@
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 use snapshot_parser::stake_meta;
-use snapshot_parser::utils::write_to_json_file;
+use snapshot_parser::utils::{write_to_json_file, write_to_text_file};
 use snapshot_parser_validator_cli::jito_mev::JITO_PROGRAM;
+use snapshot_parser_validator_cli::jito_program_hash::PROGRAM_HASH_SHORT_LEN;
 use snapshot_parser_validator_cli::jito_stake_meta::JITO_TIP_PAYMENT_PROGRAM;
 use snapshot_parser_validator_cli::scanned_accounts::scan_required_accounts;
 use snapshot_parser_validator_cli::{jito_stake_meta, validator_meta};
@@ -53,9 +54,27 @@ struct Args {
     require_priority_fee_data: bool,
 
     /// Treat a failed Jito stake meta collection as fatal; enable for clusters
-    /// (e.g. mainnet) whose downstream ETL consumes the uploaded file
+    /// (e.g. mainnet) whose downstream ETL consumes the uploaded file. Requires
+    /// --output-jito-stake-meta
     #[arg(long, env, action = clap::ArgAction::Set, default_value_t = false)]
     require_jito_stake_meta: bool,
+}
+
+impl Args {
+    /// Rejects flag combinations that would silently do nothing at runtime
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.require_jito_stake_meta && self.output_jito_stake_meta.is_none() {
+            anyhow::bail!("--require-jito-stake-meta true needs --output-jito-stake-meta, otherwise the required collection is never produced");
+        }
+
+        Ok(())
+    }
+}
+
+/// The pipeline names the uploaded collection by this hash, so it must not read 342MB
+/// of JSON to find it
+fn program_hash_path(output_jito_stake_meta: &str) -> String {
+    format!("{output_jito_stake_meta}.program-hash")
 }
 
 fn main() -> anyhow::Result<()> {
@@ -65,6 +84,7 @@ fn main() -> anyhow::Result<()> {
 
     info!("Starting snapshot parser...");
     let args: Args = Args::parse();
+    args.validate()?;
 
     info!("Creating bank from ledger path: {:?}", args.ledger_path);
     let bank = create_bank_from_ledger(&args.ledger_path)?;
@@ -148,7 +168,17 @@ fn main() -> anyhow::Result<()> {
                     )?;
                 // Jito publishes this collection pretty-printed; parity is checked byte for byte
                 write_to_json_file(&jito_stake_meta_collection, &output_path)?;
-                info!("Jito stake meta collection finished.");
+
+                let program_hash = &jito_stake_meta_collection.jito_program_hash;
+                let short_hash = program_hash
+                    .get(..PROGRAM_HASH_SHORT_LEN)
+                    .ok_or_else(|| anyhow::anyhow!("Malformed Jito program hash {program_hash}"))?;
+                // The upload step names the GCS object by this hash, so it lands next to
+                // the collection instead of being dug out of the JSON
+                write_to_text_file(&format!("{short_hash}\n"), &program_hash_path(&output_path))?;
+                info!(
+                    "Jito stake meta collection finished, Jito program hash: {program_hash} (short: {short_hash})."
+                );
                 Ok(())
             };
 
@@ -229,8 +259,12 @@ mod tests {
             "GJHtFqM9agxPmkeKjHny6qiRKrXZALvvFGiKf11QE7hy",
             "--require-priority-fee-data",
             "false",
+            "--require-jito-stake-meta",
+            "false",
         ])
         .expect("testnet Parse step argv must parse");
+        args.validate()
+            .expect("testnet Parse step argv must be valid");
 
         assert!(!args.require_priority_fee_data);
         // Testnet must keep producing the Jito collection best-effort
@@ -262,8 +296,63 @@ mod tests {
             "./stakes.json",
         ])
         .expect("minimal argv must parse");
+        args.validate().expect("minimal argv must be valid");
         assert!(args.require_priority_fee_data);
         assert!(!args.require_jito_stake_meta);
+    }
+
+    // A required collection with nowhere to write it is a configuration mistake that
+    // would otherwise pass the build without ever producing the file the ETL waits for.
+    #[test]
+    fn require_jito_stake_meta_without_an_output_is_rejected() {
+        let args = Args::try_parse_from([
+            "snapshot-parser-validator-cli",
+            "--ledger-path",
+            ".",
+            "--output-validator-meta-collection",
+            "./validators.json",
+            "--output-stake-meta-collection",
+            "./stakes.json",
+            "--require-jito-stake-meta",
+            "true",
+        ])
+        .expect("argv parses, the combination is rejected by validation");
+
+        let err = args
+            .validate()
+            .expect_err("--require-jito-stake-meta true must not be a silent no-op");
+        assert!(
+            err.to_string().contains("--output-jito-stake-meta"),
+            "the error must name the missing flag: {err}"
+        );
+    }
+
+    // Explicitly not requiring the collection stays valid without an output path
+    #[test]
+    fn not_requiring_jito_stake_meta_without_an_output_is_allowed() {
+        let args = Args::try_parse_from([
+            "snapshot-parser-validator-cli",
+            "--ledger-path",
+            ".",
+            "--output-validator-meta-collection",
+            "./validators.json",
+            "--output-stake-meta-collection",
+            "./stakes.json",
+            "--require-jito-stake-meta",
+            "false",
+        ])
+        .expect("argv must parse");
+        args.validate().expect("argv must be valid");
+        assert!(!args.require_jito_stake_meta);
+    }
+
+    // The pipeline reads this path to name the uploaded GCS object
+    #[test]
+    fn program_hash_side_file_sits_next_to_the_collection() {
+        assert_eq!(
+            program_hash_path("./jito-stake-meta.json"),
+            "./jito-stake-meta.json.program-hash"
+        );
     }
 
     // Replays the mainnet Parse step's argv: the Jito collection is mandatory there,
@@ -284,6 +373,8 @@ mod tests {
             "true",
         ])
         .expect("mainnet Parse step argv must parse");
+        args.validate()
+            .expect("mainnet Parse step argv must be valid");
 
         assert!(args.require_jito_stake_meta);
         assert!(args.require_priority_fee_data);

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -3,7 +3,6 @@ use log::LevelFilter;
 use snapshot_parser::stake_meta;
 use snapshot_parser::utils::{write_to_json_file, write_to_text_file};
 use snapshot_parser_validator_cli::jito_mev::JITO_PROGRAM;
-use snapshot_parser_validator_cli::jito_program_hash::PROGRAM_HASH_SHORT_LEN;
 use snapshot_parser_validator_cli::jito_stake_meta::JITO_TIP_PAYMENT_PROGRAM;
 use snapshot_parser_validator_cli::scanned_accounts::scan_required_accounts;
 use snapshot_parser_validator_cli::{jito_stake_meta, validator_meta};
@@ -168,13 +167,11 @@ fn main() -> anyhow::Result<()> {
                 write_to_json_file(&jito_stake_meta_collection, &output_path)?;
 
                 let program_hash = &jito_stake_meta_collection.jito_program_hash;
-                let short_hash = program_hash
-                    .get(..PROGRAM_HASH_SHORT_LEN)
-                    .ok_or_else(|| anyhow::anyhow!("Malformed Jito program hash {program_hash}"))?;
-                write_to_text_file(&format!("{short_hash}\n"), &program_hash_path(&output_path))?;
-                info!(
-                    "Jito stake meta collection finished, Jito program hash: {program_hash} (short: {short_hash})."
-                );
+                write_to_text_file(
+                    &format!("{program_hash}\n"),
+                    &program_hash_path(&output_path),
+                )?;
+                info!("Jito stake meta collection finished, Jito program hash: {program_hash}.");
                 Ok(())
             };
 

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -160,7 +160,7 @@ fn main() -> anyhow::Result<()> {
                         tip_payment_program,
                         require_priority_fee_data,
                     )?;
-                // Jito publishes this collection pretty-printed; parity is checked byte for byte
+                // Jito publishes this collection pretty-printed
                 write_to_json_file(&jito_stake_meta_collection, &output_path)?;
 
                 let program_hash = &jito_stake_meta_collection.jito_program_hash;

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -52,9 +52,7 @@ struct Args {
     #[arg(long, env, action = clap::ArgAction::Set, default_value_t = true)]
     require_priority_fee_data: bool,
 
-    /// Treat a failed Jito stake meta collection as fatal; enable for clusters
-    /// (e.g. mainnet) whose downstream ETL consumes the uploaded file. Requires
-    /// --output-jito-stake-meta
+    /// Treat a failed Jito stake meta collection as fatal; requires --output-jito-stake-meta
     #[arg(long, env, action = clap::ArgAction::Set, default_value_t = false)]
     require_jito_stake_meta: bool,
 }
@@ -69,7 +67,6 @@ impl Args {
     }
 }
 
-// A side file so the pipeline can name the upload without reading the collection JSON
 fn program_hash_path(output_jito_stake_meta: &str) -> String {
     format!("{output_jito_stake_meta}.program-hash")
 }
@@ -197,7 +194,6 @@ fn main() -> anyhow::Result<()> {
         failure = failure.or(Some(outcome));
     }
 
-    // A best-effort backup of what Jito publishes itself, unless a cluster's ETL consumes it
     if let Some(handle) = jito_stake_meta_collection_handle {
         let outcome = match handle.join() {
             Ok(Ok(())) => {
@@ -342,7 +338,6 @@ mod tests {
         );
     }
 
-    // Replays the mainnet Parse step's exact argv
     #[test]
     fn parses_mainnet_parse_step_argv() {
         let args = Args::try_parse_from([

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -1,7 +1,7 @@
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 use snapshot_parser::stake_meta;
-use snapshot_parser::utils::{write_to_json_file, write_to_text_file};
+use snapshot_parser::utils::write_to_json_file;
 use snapshot_parser_validator_cli::jito_mev::JITO_PROGRAM;
 use snapshot_parser_validator_cli::jito_stake_meta::JITO_TIP_PAYMENT_PROGRAM;
 use snapshot_parser_validator_cli::scanned_accounts::scan_required_accounts;
@@ -13,7 +13,7 @@ use {
     log::{error, info},
     snapshot_parser::bank_loader::create_bank_from_ledger,
     snapshot_parser::cli::path_parser,
-    std::path::PathBuf,
+    std::path::{Path, PathBuf},
 };
 
 #[derive(Parser, Debug)]
@@ -67,8 +67,17 @@ impl Args {
     }
 }
 
-fn program_hash_path(output_jito_stake_meta: &str) -> String {
-    format!("{output_jito_stake_meta}.program-hash")
+fn hash_named_path(output_jito_stake_meta: &str, jito_program_hash: &str) -> String {
+    let path = Path::new(output_jito_stake_meta);
+    let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+    let file_name = match path.extension() {
+        Some(extension) => format!("{stem}-{jito_program_hash}.{}", extension.to_string_lossy()),
+        None => format!("{stem}-{jito_program_hash}"),
+    };
+
+    path.with_file_name(file_name)
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn main() -> anyhow::Result<()> {
@@ -160,15 +169,11 @@ fn main() -> anyhow::Result<()> {
                         tip_payment_program,
                         require_priority_fee_data,
                     )?;
+                let hash_named_output =
+                    hash_named_path(&output_path, &jito_stake_meta_collection.jito_program_hash);
                 // Jito publishes this collection pretty-printed
-                write_to_json_file(&jito_stake_meta_collection, &output_path)?;
-
-                let program_hash = &jito_stake_meta_collection.jito_program_hash;
-                write_to_text_file(
-                    &format!("{program_hash}\n"),
-                    &program_hash_path(&output_path),
-                )?;
-                info!("Jito stake meta collection finished, Jito program hash: {program_hash}.");
+                write_to_json_file(&jito_stake_meta_collection, &hash_named_output)?;
+                info!("Jito stake meta collection finished, written to {hash_named_output}.");
                 Ok(())
             };
 
@@ -225,6 +230,9 @@ fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapshot_parser::utils::read_from_json_file;
+    use snapshot_parser_validator_cli::jito_stake_meta::JitoStakeMetaCollection;
+    use std::fs;
 
     // Replays the testnet Parse step's exact argv so the CLI contract is checked
     // without a snapshot download; would have caught --require-priority-fee-data
@@ -267,6 +275,11 @@ mod tests {
             "GJHtFqM9agxPmkeKjHny6qiRKrXZALvvFGiKf11QE7hy"
                 .parse::<Pubkey>()
                 .unwrap()
+        );
+        assert_eq!(
+            hash_named_path(&args.output_jito_stake_meta.unwrap(), HASH),
+            "./jito-stake-meta-2426260379.1775319386.json",
+            "the Parse step globs ./jito-stake-meta-*.json for exactly this name"
         );
     }
 
@@ -330,12 +343,76 @@ mod tests {
         assert!(!args.require_jito_stake_meta);
     }
 
+    const HASH: &str = "2426260379.1775319386";
+
     #[test]
-    fn program_hash_side_file_sits_next_to_the_collection() {
+    fn the_hash_goes_before_the_extension() {
         assert_eq!(
-            program_hash_path("./jito-stake-meta.json"),
-            "./jito-stake-meta.json.program-hash"
+            hash_named_path("./jito-stake-meta.json", HASH),
+            "./jito-stake-meta-2426260379.1775319386.json"
         );
+        assert_eq!(
+            hash_named_path("jito-stake-meta.json", HASH),
+            "jito-stake-meta-2426260379.1775319386.json"
+        );
+        assert_eq!(
+            hash_named_path("/mnt/out/jito-stake-meta.json", HASH),
+            "/mnt/out/jito-stake-meta-2426260379.1775319386.json"
+        );
+    }
+
+    #[test]
+    fn a_dotted_name_splits_at_the_last_extension() {
+        assert_eq!(
+            hash_named_path("./jito.stake.meta.json", HASH),
+            "./jito.stake.meta-2426260379.1775319386.json"
+        );
+    }
+
+    #[test]
+    fn a_path_without_an_extension_gets_the_hash_appended() {
+        assert_eq!(
+            hash_named_path("./jito-stake-meta", HASH),
+            "./jito-stake-meta-2426260379.1775319386"
+        );
+        assert_eq!(
+            hash_named_path("/mnt/out/jito-stake-meta", HASH),
+            "/mnt/out/jito-stake-meta-2426260379.1775319386"
+        );
+    }
+
+    #[test]
+    fn the_written_file_is_named_by_the_hash_it_carries() {
+        let dir = std::env::temp_dir().join(format!(
+            "jito-stake-meta-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let collection = JitoStakeMetaCollection {
+            stake_metas: vec![],
+            tip_distribution_program_id: Pubkey::new_unique(),
+            priority_fee_distribution_program_id: Pubkey::new_unique(),
+            bank_hash: "hash".to_string(),
+            epoch: 1002,
+            slot: 433295999,
+            jito_program_hash: HASH.to_string(),
+        };
+
+        let out = hash_named_path(
+            &dir.join("jito-stake-meta.json").to_string_lossy(),
+            &collection.jito_program_hash,
+        );
+        write_to_json_file(&collection, &out).unwrap();
+
+        let written: JitoStakeMetaCollection = read_from_json_file(&out).unwrap();
+        assert_eq!(
+            Path::new(&out).file_name().unwrap().to_string_lossy(),
+            format!("jito-stake-meta-{}.json", written.jito_program_hash),
+            "the GCS object name the stakes ETL derives from the hash must be the written file"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]
@@ -359,5 +436,10 @@ mod tests {
 
         assert!(args.require_jito_stake_meta);
         assert!(args.require_priority_fee_data);
+        assert_eq!(
+            hash_named_path(&args.output_jito_stake_meta.unwrap(), HASH),
+            "./jito-stake-meta-2426260379.1775319386.json",
+            "the Parse step globs ./jito-stake-meta-*.json for exactly this name"
+        );
     }
 }

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -31,7 +31,8 @@ struct Args {
     #[arg(long, env)]
     output_stake_meta_collection: String,
 
-    /// Path to write JSON file to for the Jito-format stake metas (e.g., jito-stake-meta.json)
+    /// Base path for the Jito-format stake metas; the Jito program hash goes before the
+    /// extension (e.g., jito-stake-meta.json is written as jito-stake-meta-<hash>.json)
     #[arg(long, env)]
     output_jito_stake_meta: Option<String>,
 

--- a/snapshot-parser-validator-cli/src/bin/cli.rs
+++ b/snapshot-parser-validator-cli/src/bin/cli.rs
@@ -51,6 +51,11 @@ struct Args {
     /// clusters (e.g. testnet) that have no priority-fee accounts
     #[arg(long, env, action = clap::ArgAction::Set, default_value_t = true)]
     require_priority_fee_data: bool,
+
+    /// Treat a failed Jito stake meta collection as fatal; enable for clusters
+    /// (e.g. mainnet) whose downstream ETL consumes the uploaded file
+    #[arg(long, env, action = clap::ArgAction::Set, default_value_t = false)]
+    require_jito_stake_meta: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -121,6 +126,7 @@ fn main() -> anyhow::Result<()> {
 
     let tip_distribution_program = args.tip_distribution_program;
     let tip_payment_program = args.tip_payment_program;
+    let require_jito_stake_meta = args.require_jito_stake_meta;
     let jito_stake_meta_collection_handle = args.output_jito_stake_meta.map(|output_path| {
         let bank = bank.clone();
         let stake_accounts = scanned_accounts.stake.clone();
@@ -168,12 +174,22 @@ fn main() -> anyhow::Result<()> {
         failure = failure.or(Some(outcome));
     }
 
-    // The Jito collection is a backup of what Jito publishes itself, it must not fail the parsing
+    // Fatal only where the collection is consumed downstream; elsewhere it stays a
+    // best-effort backup of what Jito publishes itself and must not fail the parsing
     if let Some(handle) = jito_stake_meta_collection_handle {
-        match handle.join() {
-            Ok(Ok(())) => info!("Jito stake meta collection completed successfully."),
-            Ok(Err(err)) => error!("Error in Jito stake meta thread: {err:?}"),
-            Err(err) => error!("Jito stake meta thread panicked: {err:?}"),
+        let outcome = match handle.join() {
+            Ok(Ok(())) => {
+                info!("Jito stake meta collection completed successfully.");
+                None
+            }
+            Ok(Err(err)) => Some(format!("Error in Jito stake meta thread: {err:?}")),
+            Err(err) => Some(format!("Jito stake meta thread panicked: {err:?}")),
+        };
+        if let Some(outcome) = outcome {
+            error!("{outcome}");
+            if require_jito_stake_meta {
+                failure = failure.or(Some(outcome));
+            }
         }
     }
 
@@ -217,6 +233,8 @@ mod tests {
         .expect("testnet Parse step argv must parse");
 
         assert!(!args.require_priority_fee_data);
+        // Testnet must keep producing the Jito collection best-effort
+        assert!(!args.require_jito_stake_meta);
         assert_eq!(
             args.tip_distribution_program,
             "DzvGET57TAgEDxvm3ERUM4GNcsAJdqjDLCne9sdfY4wf"
@@ -244,6 +262,30 @@ mod tests {
             "./stakes.json",
         ])
         .expect("minimal argv must parse");
+        assert!(args.require_priority_fee_data);
+        assert!(!args.require_jito_stake_meta);
+    }
+
+    // Replays the mainnet Parse step's argv: the Jito collection is mandatory there,
+    // its absence would stall the stakes ETL.
+    #[test]
+    fn parses_mainnet_parse_step_argv() {
+        let args = Args::try_parse_from([
+            "snapshot-parser-validator-cli",
+            "--ledger-path",
+            ".",
+            "--output-validator-meta-collection",
+            "./validators.json",
+            "--output-stake-meta-collection",
+            "./stakes.json",
+            "--output-jito-stake-meta",
+            "./jito-stake-meta.json",
+            "--require-jito-stake-meta",
+            "true",
+        ])
+        .expect("mainnet Parse step argv must parse");
+
+        assert!(args.require_jito_stake_meta);
         assert!(args.require_priority_fee_data);
     }
 }

--- a/snapshot-parser-validator-cli/src/jito_program_hash.rs
+++ b/snapshot-parser-validator-cli/src/jito_program_hash.rs
@@ -1,0 +1,282 @@
+use {
+    log::info,
+    solana_loader_v3_interface::state::UpgradeableLoaderState,
+    solana_program::{
+        hash::{hash, hashv},
+        pubkey::Pubkey,
+    },
+    solana_runtime::bank::Bank,
+    solana_sdk::account::ReadableAccount,
+    std::sync::Arc,
+};
+
+/// Length of the short hash the pipeline puts into the uploaded GCS object name.
+pub const PROGRAM_HASH_SHORT_LEN: usize = 16;
+
+/// Fingerprint of the on-chain Jito programs the collection was produced against.
+///
+/// The stakes ETL only consumes an uploaded collection whose GCS object name carries
+/// the Jito program hash it was pinned to (`<epoch>/jito-stake-meta-<short>.json`).
+/// When Jito redeploys, the hash changes, the object name changes with it and the ETL
+/// falls back to Jito's own bucket instead of silently reading a file produced by a
+/// parser that no longer replicates the deployed program.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JitoProgramHash {
+    /// sha256 of the concatenated program ELFs, lowercase hex (64 chars)
+    pub combined: String,
+    /// per-program sha256 of the ELF, in the order the programs were hashed
+    pub per_program: Vec<(Pubkey, String)>,
+}
+
+impl JitoProgramHash {
+    /// The prefix used to name the uploaded object; the full hash stays in the JSON.
+    pub fn short(&self) -> &str {
+        &self.combined[..PROGRAM_HASH_SHORT_LEN]
+    }
+}
+
+/// Hashes the deployed ELF of every given program, in the given order.
+///
+/// The scheme is pinned on the consumer side, so none of it may drift:
+/// the ELF is the programdata account bytes after the metadata header with the
+/// over-allocation zero padding stripped, and the combined hash is the sha256 of
+/// the ELFs concatenated in the order the program ids were passed in.
+pub fn compute_jito_program_hash(
+    bank: &Arc<Bank>,
+    program_ids: &[Pubkey],
+) -> anyhow::Result<JitoProgramHash> {
+    let elfs = program_ids
+        .iter()
+        .map(|program_id| program_elf(bank, *program_id))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let per_program = program_ids
+        .iter()
+        .zip(elfs.iter())
+        .map(|(program_id, elf)| (*program_id, to_hex(&hash(elf).to_bytes())))
+        .collect();
+    let elf_slices: Vec<&[u8]> = elfs.iter().map(Vec::as_slice).collect();
+    let combined = to_hex(&hashv(&elf_slices).to_bytes());
+
+    let program_hash = JitoProgramHash {
+        combined,
+        per_program,
+    };
+    for (program_id, program_hash) in &program_hash.per_program {
+        info!("Jito program {program_id} ELF sha256: {program_hash}");
+    }
+    info!(
+        "Jito program hash: {} (short: {})",
+        program_hash.combined,
+        program_hash.short()
+    );
+
+    Ok(program_hash)
+}
+
+/// Loads the deployed ELF of an upgradeable program from the bank.
+fn program_elf(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> {
+    let program_account = bank.get_account(&program_id).ok_or_else(|| {
+        anyhow::anyhow!("Jito program account {program_id} not found in the bank")
+    })?;
+    let programdata_address = programdata_address(program_account.data())
+        .map_err(|err| anyhow::anyhow!("Jito program account {program_id}: {err}"))?;
+
+    let programdata_account = bank.get_account(&programdata_address).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Jito programdata account {programdata_address} of program {program_id} not found in the bank"
+        )
+    })?;
+    let elf = elf_from_programdata(programdata_account.data()).map_err(|err| {
+        anyhow::anyhow!(
+            "Jito programdata account {programdata_address} of program {program_id}: {err}"
+        )
+    })?;
+
+    info!(
+        "Jito program {program_id} deployed from programdata {programdata_address}: {} ELF bytes",
+        elf.len()
+    );
+    Ok(elf.to_vec())
+}
+
+/// The program account of the upgradeable loader only points at the programdata account.
+fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
+    match bincode::deserialize(data) {
+        Ok(UpgradeableLoaderState::Program {
+            programdata_address,
+        }) => Ok(programdata_address),
+        Ok(state) => anyhow::bail!("expected an upgradeable Program account, got {state:?}"),
+        Err(err) => anyhow::bail!("failed to parse the upgradeable Program account: {err}"),
+    }
+}
+
+/// The ELF follows the programdata metadata header; the account is over-allocated so
+/// that a bigger upgrade fits, and that spare room is zero padding, not program bytes.
+fn elf_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
+    match bincode::deserialize(data) {
+        Ok(UpgradeableLoaderState::ProgramData { .. }) => {}
+        Ok(state) => anyhow::bail!("expected a ProgramData account, got {state:?}"),
+        Err(err) => anyhow::bail!("failed to parse the ProgramData header: {err}"),
+    }
+
+    let header_len = UpgradeableLoaderState::size_of_programdata_metadata();
+    let body = data.get(header_len..).ok_or_else(|| {
+        anyhow::anyhow!(
+            "account of {} bytes is shorter than the {header_len} byte ProgramData header",
+            data.len()
+        )
+    })?;
+    let elf_len = body
+        .iter()
+        .rposition(|byte| *byte != 0)
+        .map_or(0, |last| last + 1);
+    if elf_len == 0 {
+        anyhow::bail!("no ELF bytes found after the {header_len} byte ProgramData header");
+    }
+
+    Ok(&body[..elf_len])
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+
+    bytes.iter().fold(String::new(), |mut hex, byte| {
+        let _ = write!(hex, "{byte:02x}");
+        hex
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Zero padding of the over-allocated account, big enough to prove it is stripped
+    const PADDING: usize = 128;
+
+    fn programdata_account(elf: &[u8]) -> Vec<u8> {
+        let mut data = bincode::serialize(&UpgradeableLoaderState::ProgramData {
+            slot: 123_456,
+            upgrade_authority_address: Some(Pubkey::new_unique()),
+        })
+        .unwrap();
+        assert_eq!(
+            data.len(),
+            UpgradeableLoaderState::size_of_programdata_metadata(),
+            "the ProgramData header the ELF offset is derived from"
+        );
+        data.extend_from_slice(elf);
+        data.extend_from_slice(&[0_u8; PADDING]);
+        data
+    }
+
+    #[test]
+    fn programdata_metadata_header_is_45_bytes() {
+        // The consumer side is pinned to this offset; a change of it is a format change
+        assert_eq!(UpgradeableLoaderState::size_of_programdata_metadata(), 45);
+    }
+
+    #[test]
+    fn strips_the_header_and_the_zero_padding() {
+        let elf = bytes_1_to_32();
+        let account = programdata_account(&elf);
+        assert_eq!(account.len(), 45 + elf.len() + PADDING);
+        assert_eq!(elf_from_programdata(&account).unwrap(), elf.as_slice());
+    }
+
+    // Pins the exact arithmetic the stakes ETL depends on: the digests below are the
+    // sha256 of the synthetic ELF payloads, and the combined one of their concatenation.
+    #[test]
+    fn hashes_the_sliced_elf_bytes() {
+        let tip_elf = bytes_1_to_32();
+        let priority_elf = priority_payload();
+
+        assert_eq!(
+            to_hex(&hash(elf_from_programdata(&programdata_account(&tip_elf)).unwrap()).to_bytes()),
+            "ae216c2ef5247a3782c135efa279a3e4cdc61094270f5d2be58c6204b7a612c9"
+        );
+        assert_eq!(
+            to_hex(
+                &hash(elf_from_programdata(&programdata_account(&priority_elf)).unwrap())
+                    .to_bytes()
+            ),
+            "baefa1f403ba2fd6aac32e6be36821e8f3253de02aad07f804a349aaefc60b24"
+        );
+        assert_eq!(
+            to_hex(&hashv(&[tip_elf.as_slice(), priority_elf.as_slice()]).to_bytes()),
+            "e4e1ba6f03b8a9c60c2875d51703481abd602e6308a8f51a8cc1d6965c81a3ae"
+        );
+    }
+
+    // The order of the programs is part of the scheme, the combined hash must not commute
+    #[test]
+    fn combined_hash_depends_on_the_program_order() {
+        let tip_elf = bytes_1_to_32();
+        let priority_elf = priority_payload();
+        assert_ne!(
+            to_hex(&hashv(&[tip_elf.as_slice(), priority_elf.as_slice()]).to_bytes()),
+            to_hex(&hashv(&[priority_elf.as_slice(), tip_elf.as_slice()]).to_bytes())
+        );
+    }
+
+    #[test]
+    fn reads_the_programdata_address_of_a_program_account() {
+        let programdata = Pubkey::new_unique();
+        let data = bincode::serialize(&UpgradeableLoaderState::Program {
+            programdata_address: programdata,
+        })
+        .unwrap();
+        assert_eq!(data.len(), UpgradeableLoaderState::size_of_program());
+        assert_eq!(programdata_address(&data).unwrap(), programdata);
+    }
+
+    #[test]
+    fn rejects_accounts_of_the_wrong_upgradeable_loader_state() {
+        let buffer = bincode::serialize(&UpgradeableLoaderState::Buffer {
+            authority_address: Some(Pubkey::new_unique()),
+        })
+        .unwrap();
+        assert!(programdata_address(&buffer).is_err());
+        assert!(elf_from_programdata(&buffer).is_err());
+
+        let program = bincode::serialize(&UpgradeableLoaderState::Program {
+            programdata_address: Pubkey::new_unique(),
+        })
+        .unwrap();
+        assert!(elf_from_programdata(&program).is_err());
+    }
+
+    #[test]
+    fn rejects_a_programdata_account_without_elf_bytes() {
+        assert!(elf_from_programdata(&programdata_account(&[])).is_err());
+        assert!(elf_from_programdata(&[]).is_err());
+    }
+
+    #[test]
+    fn short_hash_is_the_first_16_hex_chars() {
+        let program_hash = JitoProgramHash {
+            combined: "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
+                .to_string(),
+            per_program: vec![],
+        };
+        assert_eq!(program_hash.combined.len(), 64);
+        assert_eq!(program_hash.short(), "5dcd612ee1fd3aa3");
+        assert_eq!(program_hash.short().len(), PROGRAM_HASH_SHORT_LEN);
+    }
+
+    #[test]
+    fn formats_bytes_as_lowercase_hex() {
+        assert_eq!(to_hex(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
+        assert_eq!(to_hex(&[]), "");
+    }
+
+    fn bytes_1_to_32() -> Vec<u8> {
+        (1..=32_u8).collect()
+    }
+
+    fn priority_payload() -> Vec<u8> {
+        let mut payload = b"priority-fee elf payload".to_vec();
+        payload.push(7);
+        payload
+    }
+}

--- a/snapshot-parser-validator-cli/src/jito_program_hash.rs
+++ b/snapshot-parser-validator-cli/src/jito_program_hash.rs
@@ -1,7 +1,3 @@
-//! POSIX cksum CRC-32 of the deployed tip-distribution and priority-fee programs, joined as
-//! `<crc_tip>.<crc_priority>`. Reproduce either half by hand with
-//! `solana program dump <program_id> f.so && cksum f.so`.
-
 use {
     crc::{Crc, CRC_32_CKSUM},
     log::info,
@@ -12,12 +8,8 @@ use {
     std::sync::Arc,
 };
 
-/// Poly 0x04C11DB7, non-reflected, complemented. The catalogued algorithm stops there; the
-/// byte count `cksum` folds in on top of it is [`cksum`]'s job.
 const CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
 
-/// What plain `cksum` prints: the CRC-32 of the bytes followed by their count, encoded base-256
-/// little-endian with leading zero bytes dropped (so an empty input folds in nothing).
 fn cksum(bytes: &[u8]) -> u32 {
     let mut digest = CRC.digest();
     digest.update(bytes);
@@ -73,7 +65,6 @@ pub fn compute_jito_program_hash(
     Ok(program_hash)
 }
 
-/// The bytes `solana program dump <program_id>` writes to a file
 fn program_dump(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> {
     let program_account = bank.get_account(&program_id).ok_or_else(|| {
         anyhow::anyhow!("Jito program account {program_id} not found in the bank")
@@ -109,8 +100,6 @@ fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
     }
 }
 
-// Everything after the metadata, zero padding of the over-allocated account included: the CLI
-// dumps the tail verbatim, so stripping anything here would break hand-reproduction
 fn dump_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
     match bincode::deserialize(data) {
         Ok(UpgradeableLoaderState::ProgramData { .. }) => {}
@@ -154,7 +143,6 @@ mod tests {
         data
     }
 
-    // Vectors produced by the coreutils `cksum` binary, so the crate constant stays pinned to it
     #[test]
     fn crc_matches_the_posix_cksum_binary() {
         assert_eq!(
@@ -165,10 +153,10 @@ mod tests {
         let all_bytes: Vec<u8> = (0..=255_u8).collect();
         assert_eq!(cksum(&all_bytes), 1_313_719_201);
 
-        // Without the byte count folded in the CRC is a different, non-reproducible number
         assert_eq!(
             CRC.checksum(b"The quick brown fox jumps over the lazy dog"),
-            917_995_649
+            917_995_649,
+            "without the byte count folded in the CRC is a different, non-reproducible number"
         );
     }
 
@@ -189,7 +177,6 @@ mod tests {
         assert!(dump[elf.len()..].iter().all(|byte| *byte == 0));
     }
 
-    // The same bytes fed to `cksum` after `solana program dump`
     #[test]
     fn checksums_the_dumped_bytes() {
         assert_eq!(

--- a/snapshot-parser-validator-cli/src/jito_program_hash.rs
+++ b/snapshot-parser-validator-cli/src/jito_program_hash.rs
@@ -1,20 +1,35 @@
-//! sha256 over the deployed tip-distribution and priority-fee program ELFs, in that
-//! order: programdata bytes after the 45 byte loader metadata, trailing zeros stripped.
-//! The stakes ETL pins this scheme and finds the upload by the first 16 hex chars.
+//! POSIX cksum CRC-32 of the deployed tip-distribution and priority-fee programs, joined as
+//! `<crc_tip>.<crc_priority>`. Reproduce either half by hand with
+//! `solana program dump <program_id> f.so && cksum f.so`.
 
 use {
+    crc::{Crc, CRC_32_CKSUM},
     log::info,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
-    solana_program::{
-        hash::{hash, hashv},
-        pubkey::Pubkey,
-    },
+    solana_program::pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_sdk::account::ReadableAccount,
     std::sync::Arc,
 };
 
-pub const PROGRAM_HASH_SHORT_LEN: usize = 16;
+/// Poly 0x04C11DB7, non-reflected, complemented. The catalogued algorithm stops there; the
+/// byte count `cksum` folds in on top of it is [`cksum`]'s job.
+const CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
+
+/// What plain `cksum` prints: the CRC-32 of the bytes followed by their count, encoded base-256
+/// little-endian with leading zero bytes dropped (so an empty input folds in nothing).
+fn cksum(bytes: &[u8]) -> u32 {
+    let mut digest = CRC.digest();
+    digest.update(bytes);
+
+    let mut remaining = bytes.len();
+    while remaining > 0 {
+        digest.update(&[remaining as u8]);
+        remaining >>= 8;
+    }
+
+    digest.finalize()
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JitoProgramHash {
@@ -23,8 +38,17 @@ pub struct JitoProgramHash {
 }
 
 impl JitoProgramHash {
-    pub fn short(&self) -> &str {
-        &self.combined[..PROGRAM_HASH_SHORT_LEN]
+    fn new(per_program: Vec<(Pubkey, String)>) -> Self {
+        let combined = per_program
+            .iter()
+            .map(|(_, crc)| crc.as_str())
+            .collect::<Vec<_>>()
+            .join(".");
+
+        Self {
+            combined,
+            per_program,
+        }
     }
 }
 
@@ -32,36 +56,25 @@ pub fn compute_jito_program_hash(
     bank: &Arc<Bank>,
     program_ids: &[Pubkey],
 ) -> anyhow::Result<JitoProgramHash> {
-    let elfs = program_ids
-        .iter()
-        .map(|program_id| program_elf(bank, *program_id))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-
     let per_program = program_ids
         .iter()
-        .zip(elfs.iter())
-        .map(|(program_id, elf)| (*program_id, to_hex(&hash(elf).to_bytes())))
-        .collect();
-    let elf_slices: Vec<&[u8]> = elfs.iter().map(Vec::as_slice).collect();
-    let combined = to_hex(&hashv(&elf_slices).to_bytes());
+        .map(|program_id| {
+            let dump = program_dump(bank, *program_id)?;
+            Ok((*program_id, cksum(&dump).to_string()))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let program_hash = JitoProgramHash {
-        combined,
-        per_program,
-    };
-    for (program_id, program_hash) in &program_hash.per_program {
-        info!("Jito program {program_id} ELF sha256: {program_hash}");
+    let program_hash = JitoProgramHash::new(per_program);
+    for (program_id, crc) in &program_hash.per_program {
+        info!("Jito program {program_id} cksum CRC-32: {crc}");
     }
-    info!(
-        "Jito program hash: {} (short: {})",
-        program_hash.combined,
-        program_hash.short()
-    );
+    info!("Jito program hash: {}", program_hash.combined);
 
     Ok(program_hash)
 }
 
-fn program_elf(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> {
+/// The bytes `solana program dump <program_id>` writes to a file
+fn program_dump(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> {
     let program_account = bank.get_account(&program_id).ok_or_else(|| {
         anyhow::anyhow!("Jito program account {program_id} not found in the bank")
     })?;
@@ -73,17 +86,17 @@ fn program_elf(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> 
             "Jito programdata account {programdata_address} of program {program_id} not found in the bank"
         )
     })?;
-    let elf = elf_from_programdata(programdata_account.data()).map_err(|err| {
+    let dump = dump_from_programdata(programdata_account.data()).map_err(|err| {
         anyhow::anyhow!(
             "Jito programdata account {programdata_address} of program {program_id}: {err}"
         )
     })?;
 
     info!(
-        "Jito program {program_id} deployed from programdata {programdata_address}: {} ELF bytes",
-        elf.len()
+        "Jito program {program_id} deployed from programdata {programdata_address}: {} dumped bytes",
+        dump.len()
     );
-    Ok(elf.to_vec())
+    Ok(dump.to_vec())
 }
 
 fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
@@ -96,8 +109,9 @@ fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
     }
 }
 
-// The account is over-allocated so a bigger upgrade fits; the spare room is zero padding
-fn elf_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
+// Everything after the metadata, zero padding of the over-allocated account included: the CLI
+// dumps the tail verbatim, so stripping anything here would break hand-reproduction
+fn dump_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
     match bincode::deserialize(data) {
         Ok(UpgradeableLoaderState::ProgramData { .. }) => {}
         Ok(state) => anyhow::bail!("expected a ProgramData account, got {state:?}"),
@@ -111,24 +125,11 @@ fn elf_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
             data.len()
         )
     })?;
-    let elf_len = body
-        .iter()
-        .rposition(|byte| *byte != 0)
-        .map_or(0, |last| last + 1);
-    if elf_len == 0 {
-        anyhow::bail!("no ELF bytes found after the {header_len} byte ProgramData header");
+    if body.is_empty() {
+        anyhow::bail!("no program bytes found after the {header_len} byte ProgramData header");
     }
 
-    Ok(&body[..elf_len])
-}
-
-fn to_hex(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-
-    bytes.iter().fold(String::new(), |mut hex, byte| {
-        let _ = write!(hex, "{byte:02x}");
-        hex
-    })
+    Ok(body)
 }
 
 #[cfg(test)]
@@ -146,11 +147,29 @@ mod tests {
         assert_eq!(
             data.len(),
             UpgradeableLoaderState::size_of_programdata_metadata(),
-            "the ProgramData header the ELF offset is derived from"
+            "the ProgramData header the dump offset is derived from"
         );
         data.extend_from_slice(elf);
         data.extend_from_slice(&[0_u8; PADDING]);
         data
+    }
+
+    // Vectors produced by the coreutils `cksum` binary, so the crate constant stays pinned to it
+    #[test]
+    fn crc_matches_the_posix_cksum_binary() {
+        assert_eq!(
+            cksum(b"The quick brown fox jumps over the lazy dog"),
+            2_074_844_392
+        );
+        assert_eq!(cksum(b""), 4_294_967_295);
+        let all_bytes: Vec<u8> = (0..=255_u8).collect();
+        assert_eq!(cksum(&all_bytes), 1_313_719_201);
+
+        // Without the byte count folded in the CRC is a different, non-reproducible number
+        assert_eq!(
+            CRC.checksum(b"The quick brown fox jumps over the lazy dog"),
+            917_995_649
+        );
     }
 
     #[test]
@@ -159,42 +178,42 @@ mod tests {
     }
 
     #[test]
-    fn strips_the_header_and_the_zero_padding() {
+    fn strips_the_header_and_keeps_the_zero_padding() {
         let elf = bytes_1_to_32();
         let account = programdata_account(&elf);
         assert_eq!(account.len(), 45 + elf.len() + PADDING);
-        assert_eq!(elf_from_programdata(&account).unwrap(), elf.as_slice());
+
+        let dump = dump_from_programdata(&account).unwrap();
+        assert_eq!(dump.len(), elf.len() + PADDING);
+        assert_eq!(&dump[..elf.len()], elf.as_slice());
+        assert!(dump[elf.len()..].iter().all(|byte| *byte == 0));
     }
 
+    // The same bytes fed to `cksum` after `solana program dump`
     #[test]
-    fn hashes_the_sliced_elf_bytes() {
-        let tip_elf = bytes_1_to_32();
-        let priority_elf = priority_payload();
-
+    fn checksums_the_dumped_bytes() {
         assert_eq!(
-            to_hex(&hash(elf_from_programdata(&programdata_account(&tip_elf)).unwrap()).to_bytes()),
-            "ae216c2ef5247a3782c135efa279a3e4cdc61094270f5d2be58c6204b7a612c9"
+            cksum(dump_from_programdata(&programdata_account(&bytes_1_to_32())).unwrap()),
+            2_964_876_213
         );
         assert_eq!(
-            to_hex(
-                &hash(elf_from_programdata(&programdata_account(&priority_elf)).unwrap())
-                    .to_bytes()
-            ),
-            "baefa1f403ba2fd6aac32e6be36821e8f3253de02aad07f804a349aaefc60b24"
-        );
-        assert_eq!(
-            to_hex(&hashv(&[tip_elf.as_slice(), priority_elf.as_slice()]).to_bytes()),
-            "e4e1ba6f03b8a9c60c2875d51703481abd602e6308a8f51a8cc1d6965c81a3ae"
+            cksum(dump_from_programdata(&programdata_account(&priority_payload())).unwrap()),
+            3_844_531_109
         );
     }
 
     #[test]
-    fn combined_hash_depends_on_the_program_order() {
-        let tip_elf = bytes_1_to_32();
-        let priority_elf = priority_payload();
-        assert_ne!(
-            to_hex(&hashv(&[tip_elf.as_slice(), priority_elf.as_slice()]).to_bytes()),
-            to_hex(&hashv(&[priority_elf.as_slice(), tip_elf.as_slice()]).to_bytes())
+    fn combined_hash_dot_joins_the_per_program_crcs_in_order() {
+        let tip = (Pubkey::new_unique(), "2964876213".to_string());
+        let priority = (Pubkey::new_unique(), "3844531109".to_string());
+
+        assert_eq!(
+            JitoProgramHash::new(vec![tip.clone(), priority.clone()]).combined,
+            "2964876213.3844531109"
+        );
+        assert_eq!(
+            JitoProgramHash::new(vec![priority, tip]).combined,
+            "3844531109.2964876213"
         );
     }
 
@@ -216,37 +235,28 @@ mod tests {
         })
         .unwrap();
         assert!(programdata_address(&buffer).is_err());
-        assert!(elf_from_programdata(&buffer).is_err());
+        assert!(dump_from_programdata(&buffer).is_err());
 
         let program = bincode::serialize(&UpgradeableLoaderState::Program {
             programdata_address: Pubkey::new_unique(),
         })
         .unwrap();
-        assert!(elf_from_programdata(&program).is_err());
+        assert!(dump_from_programdata(&program).is_err());
     }
 
     #[test]
-    fn rejects_a_programdata_account_without_elf_bytes() {
-        assert!(elf_from_programdata(&programdata_account(&[])).is_err());
-        assert!(elf_from_programdata(&[]).is_err());
-    }
-
-    #[test]
-    fn short_hash_is_the_first_16_hex_chars() {
-        let program_hash = JitoProgramHash {
-            combined: "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
-                .to_string(),
-            per_program: vec![],
-        };
-        assert_eq!(program_hash.combined.len(), 64);
-        assert_eq!(program_hash.short(), "5dcd612ee1fd3aa3");
-        assert_eq!(program_hash.short().len(), PROGRAM_HASH_SHORT_LEN);
-    }
-
-    #[test]
-    fn formats_bytes_as_lowercase_hex() {
-        assert_eq!(to_hex(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
-        assert_eq!(to_hex(&[]), "");
+    fn rejects_a_programdata_account_without_a_body() {
+        let header = bincode::serialize(&UpgradeableLoaderState::ProgramData {
+            slot: 1,
+            upgrade_authority_address: Some(Pubkey::new_unique()),
+        })
+        .unwrap();
+        assert_eq!(
+            header.len(),
+            UpgradeableLoaderState::size_of_programdata_metadata()
+        );
+        assert!(dump_from_programdata(&header).is_err());
+        assert!(dump_from_programdata(&[]).is_err());
     }
 
     fn bytes_1_to_32() -> Vec<u8> {

--- a/snapshot-parser-validator-cli/src/jito_program_hash.rs
+++ b/snapshot-parser-validator-cli/src/jito_program_hash.rs
@@ -1,3 +1,7 @@
+//! sha256 over the deployed tip-distribution and priority-fee program ELFs, in that
+//! order: programdata bytes after the 45 byte loader metadata, trailing zeros stripped.
+//! The stakes ETL pins this scheme and finds the upload by the first 16 hex chars.
+
 use {
     log::info,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
@@ -10,37 +14,20 @@ use {
     std::sync::Arc,
 };
 
-/// Length of the short hash the pipeline puts into the uploaded GCS object name.
 pub const PROGRAM_HASH_SHORT_LEN: usize = 16;
 
-/// Fingerprint of the on-chain Jito programs the collection was produced against.
-///
-/// The stakes ETL only consumes an uploaded collection whose GCS object name carries
-/// the Jito program hash it was pinned to (`<epoch>/jito-stake-meta-<short>.json`).
-/// When Jito redeploys, the hash changes, the object name changes with it and the ETL
-/// falls back to Jito's own bucket instead of silently reading a file produced by a
-/// parser that no longer replicates the deployed program.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JitoProgramHash {
-    /// sha256 of the concatenated program ELFs, lowercase hex (64 chars)
     pub combined: String,
-    /// per-program sha256 of the ELF, in the order the programs were hashed
     pub per_program: Vec<(Pubkey, String)>,
 }
 
 impl JitoProgramHash {
-    /// The prefix used to name the uploaded object; the full hash stays in the JSON.
     pub fn short(&self) -> &str {
         &self.combined[..PROGRAM_HASH_SHORT_LEN]
     }
 }
 
-/// Hashes the deployed ELF of every given program, in the given order.
-///
-/// The scheme is pinned on the consumer side, so none of it may drift:
-/// the ELF is the programdata account bytes after the metadata header with the
-/// over-allocation zero padding stripped, and the combined hash is the sha256 of
-/// the ELFs concatenated in the order the program ids were passed in.
 pub fn compute_jito_program_hash(
     bank: &Arc<Bank>,
     program_ids: &[Pubkey],
@@ -74,7 +61,6 @@ pub fn compute_jito_program_hash(
     Ok(program_hash)
 }
 
-/// Loads the deployed ELF of an upgradeable program from the bank.
 fn program_elf(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> {
     let program_account = bank.get_account(&program_id).ok_or_else(|| {
         anyhow::anyhow!("Jito program account {program_id} not found in the bank")
@@ -100,7 +86,6 @@ fn program_elf(bank: &Arc<Bank>, program_id: Pubkey) -> anyhow::Result<Vec<u8>> 
     Ok(elf.to_vec())
 }
 
-/// The program account of the upgradeable loader only points at the programdata account.
 fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
     match bincode::deserialize(data) {
         Ok(UpgradeableLoaderState::Program {
@@ -111,8 +96,7 @@ fn programdata_address(data: &[u8]) -> anyhow::Result<Pubkey> {
     }
 }
 
-/// The ELF follows the programdata metadata header; the account is over-allocated so
-/// that a bigger upgrade fits, and that spare room is zero padding, not program bytes.
+// The account is over-allocated so a bigger upgrade fits; the spare room is zero padding
 fn elf_from_programdata(data: &[u8]) -> anyhow::Result<&[u8]> {
     match bincode::deserialize(data) {
         Ok(UpgradeableLoaderState::ProgramData { .. }) => {}
@@ -151,7 +135,6 @@ fn to_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
-    // Zero padding of the over-allocated account, big enough to prove it is stripped
     const PADDING: usize = 128;
 
     fn programdata_account(elf: &[u8]) -> Vec<u8> {
@@ -172,7 +155,6 @@ mod tests {
 
     #[test]
     fn programdata_metadata_header_is_45_bytes() {
-        // The consumer side is pinned to this offset; a change of it is a format change
         assert_eq!(UpgradeableLoaderState::size_of_programdata_metadata(), 45);
     }
 
@@ -184,8 +166,6 @@ mod tests {
         assert_eq!(elf_from_programdata(&account).unwrap(), elf.as_slice());
     }
 
-    // Pins the exact arithmetic the stakes ETL depends on: the digests below are the
-    // sha256 of the synthetic ELF payloads, and the combined one of their concatenation.
     #[test]
     fn hashes_the_sliced_elf_bytes() {
         let tip_elf = bytes_1_to_32();
@@ -208,7 +188,6 @@ mod tests {
         );
     }
 
-    // The order of the programs is part of the scheme, the combined hash must not commute
     #[test]
     fn combined_hash_depends_on_the_program_order() {
         let tip_elf = bytes_1_to_32();

--- a/snapshot-parser-validator-cli/src/jito_stake_meta.rs
+++ b/snapshot-parser-validator-cli/src/jito_stake_meta.rs
@@ -47,7 +47,6 @@ pub struct JitoStakeMetaCollection {
     pub bank_hash: String,
     pub epoch: Epoch,
     pub slot: u64,
-    // Extra field on top of Jito's format; a collection produced by Jito has none
     #[serde(default)]
     pub jito_program_hash: String,
 }

--- a/snapshot-parser-validator-cli/src/jito_stake_meta.rs
+++ b/snapshot-parser-validator-cli/src/jito_stake_meta.rs
@@ -517,17 +517,13 @@ mod tests {
             bank_hash: "hash".to_string(),
             epoch: 1002,
             slot: 433295999,
-            jito_program_hash: "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
-                .to_string(),
+            jito_program_hash: "2426260379.1775319386".to_string(),
         };
 
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&collection).unwrap()).unwrap();
         assert_eq!(json["epoch"], 1002);
-        assert_eq!(
-            json["jito_program_hash"],
-            "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
-        );
+        assert_eq!(json["jito_program_hash"], "2426260379.1775319386");
         assert_eq!(
             json["tip_distribution_program_id"],
             JITO_PROGRAM.to_string()

--- a/snapshot-parser-validator-cli/src/jito_stake_meta.rs
+++ b/snapshot-parser-validator-cli/src/jito_stake_meta.rs
@@ -2,6 +2,7 @@ use crate::jito_mev::TIP_DISTRIBUTION_ACCOUNT_DISCRIMINATOR;
 use crate::jito_priority_fee::{
     JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM, PRIORITY_FEE_DISTRIBUTION_ACCOUNT_DISCRIMINATOR,
 };
+use crate::jito_program_hash::compute_jito_program_hash;
 use crate::utils::jito_parser::{
     get_epoch_created_at, read_jito_commission_and_epoch, read_merkle_root_upload_authority,
 };
@@ -46,6 +47,11 @@ pub struct JitoStakeMetaCollection {
     pub bank_hash: String,
     pub epoch: Epoch,
     pub slot: u64,
+    // Extra field on top of the format Jito publishes: the sha256 of the deployed Jito
+    // program ELFs this collection replicates. Consumers ignore unknown fields, and
+    // reading a collection produced elsewhere (without the field) must keep working.
+    #[serde(default)]
+    pub jito_program_hash: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -147,6 +153,15 @@ pub fn generate_jito_stake_meta_collection(
 ) -> anyhow::Result<JitoStakeMetaCollection> {
     assert!(bank.is_frozen());
     let epoch = bank.epoch();
+
+    // Fingerprints the programs this collection replicates; a redeploy must be visible
+    // to the consumer, so a program that cannot be hashed fails the whole collection
+    let priority_fee_distribution_program: Pubkey =
+        JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?;
+    let program_hash = compute_jito_program_hash(
+        bank,
+        &[tip_distribution_program, priority_fee_distribution_program],
+    )?;
 
     let last_slot_in_epoch = bank.epoch_schedule().get_last_slot_in_epoch(epoch);
     if bank.slot() != last_slot_in_epoch {
@@ -281,10 +296,11 @@ pub fn generate_jito_stake_meta_collection(
     Ok(JitoStakeMetaCollection {
         stake_metas,
         tip_distribution_program_id: tip_distribution_program,
-        priority_fee_distribution_program_id: JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?,
+        priority_fee_distribution_program_id: priority_fee_distribution_program,
         bank_hash: bank.hash().to_string(),
         epoch,
         slot: bank.slot(),
+        jito_program_hash: program_hash.combined,
     })
 }
 
@@ -505,11 +521,17 @@ mod tests {
             bank_hash: "hash".to_string(),
             epoch: 1002,
             slot: 433295999,
+            jito_program_hash: "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
+                .to_string(),
         };
 
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&collection).unwrap()).unwrap();
         assert_eq!(json["epoch"], 1002);
+        assert_eq!(
+            json["jito_program_hash"],
+            "5dcd612ee1fd3aa36f2d67039a1e64093e2687f7331494fc8bcaed8070b28056"
+        );
         assert_eq!(
             json["tip_distribution_program_id"],
             JITO_PROGRAM.to_string()
@@ -528,6 +550,22 @@ mod tests {
         );
         assert!(stake_meta["maybe_priority_fee_distribution_meta"].is_null());
         assert_eq!(stake_meta["delegations"][0]["lamports_delegated"], 1000);
+    }
+
+    // The output stays a superset of what Jito publishes: the extra hash is appended,
+    // and a collection produced without it still reads back.
+    #[test]
+    fn reads_a_collection_without_the_program_hash() {
+        let jito_json = serde_json::json!({
+            "stake_metas": [],
+            "tip_distribution_program_id": JITO_PROGRAM,
+            "priority_fee_distribution_program_id": JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM,
+            "bank_hash": "hash",
+            "epoch": 1002,
+            "slot": 433295999,
+        });
+        let collection: JitoStakeMetaCollection = serde_json::from_value(jito_json).unwrap();
+        assert_eq!(collection.jito_program_hash, "");
     }
 
     #[test]

--- a/snapshot-parser-validator-cli/src/jito_stake_meta.rs
+++ b/snapshot-parser-validator-cli/src/jito_stake_meta.rs
@@ -47,9 +47,7 @@ pub struct JitoStakeMetaCollection {
     pub bank_hash: String,
     pub epoch: Epoch,
     pub slot: u64,
-    // Extra field on top of the format Jito publishes: the sha256 of the deployed Jito
-    // program ELFs this collection replicates. Consumers ignore unknown fields, and
-    // reading a collection produced elsewhere (without the field) must keep working.
+    // Extra field on top of Jito's format; a collection produced by Jito has none
     #[serde(default)]
     pub jito_program_hash: String,
 }
@@ -154,8 +152,6 @@ pub fn generate_jito_stake_meta_collection(
     assert!(bank.is_frozen());
     let epoch = bank.epoch();
 
-    // Fingerprints the programs this collection replicates; a redeploy must be visible
-    // to the consumer, so a program that cannot be hashed fails the whole collection
     let priority_fee_distribution_program: Pubkey =
         JITO_PRIORITY_FEE_DISTRIBUTION_PROGRAM.try_into()?;
     let program_hash = compute_jito_program_hash(
@@ -552,8 +548,6 @@ mod tests {
         assert_eq!(stake_meta["delegations"][0]["lamports_delegated"], 1000);
     }
 
-    // The output stays a superset of what Jito publishes: the extra hash is appended,
-    // and a collection produced without it still reads back.
     #[test]
     fn reads_a_collection_without_the_program_hash() {
         let jito_json = serde_json::json!({

--- a/snapshot-parser-validator-cli/src/lib.rs
+++ b/snapshot-parser-validator-cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod jito_mev;
 pub mod jito_priority_fee;
+pub mod jito_program_hash;
 pub mod jito_stake_meta;
 pub mod scanned_accounts;
 pub mod utils;

--- a/snapshot-parser/src/utils.rs
+++ b/snapshot-parser/src/utils.rs
@@ -46,6 +46,14 @@ pub fn write_to_json_file<T: Serialize>(data: &T, out_path: &str) -> anyhow::Res
     })
 }
 
+pub fn write_to_text_file(content: &str, out_path: &str) -> anyhow::Result<()> {
+    write_atomic(out_path, |writer| {
+        writer.write_all(content.as_bytes())?;
+
+        Ok(())
+    })
+}
+
 pub fn read_from_json_file<P: AsRef<Path>, T: DeserializeOwned>(in_path: &P) -> anyhow::Result<T> {
     let file = File::open(in_path)?;
     let reader = BufReader::new(file);
@@ -105,6 +113,18 @@ mod tests {
         assert_eq!(
             fs::read_to_string(out.path()).unwrap(),
             serde_json::to_string_pretty(&data).unwrap()
+        );
+        assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
+    }
+
+    #[test]
+    fn text_writer_writes_the_content_verbatim() {
+        let out = OutDir::new("text");
+        write_to_text_file("5dcd612ee1fd3aa3\n", &out.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(out.path()).unwrap(),
+            "5dcd612ee1fd3aa3\n"
         );
         assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
     }

--- a/snapshot-parser/src/utils.rs
+++ b/snapshot-parser/src/utils.rs
@@ -46,14 +46,6 @@ pub fn write_to_json_file<T: Serialize>(data: &T, out_path: &str) -> anyhow::Res
     })
 }
 
-pub fn write_to_text_file(content: &str, out_path: &str) -> anyhow::Result<()> {
-    write_atomic(out_path, |writer| {
-        writer.write_all(content.as_bytes())?;
-
-        Ok(())
-    })
-}
-
 pub fn read_from_json_file<P: AsRef<Path>, T: DeserializeOwned>(in_path: &P) -> anyhow::Result<T> {
     let file = File::open(in_path)?;
     let reader = BufReader::new(file);
@@ -113,18 +105,6 @@ mod tests {
         assert_eq!(
             fs::read_to_string(out.path()).unwrap(),
             serde_json::to_string_pretty(&data).unwrap()
-        );
-        assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
-    }
-
-    #[test]
-    fn text_writer_writes_the_content_verbatim() {
-        let out = OutDir::new("text");
-        write_to_text_file("5dcd612ee1fd3aa3\n", &out.path()).unwrap();
-
-        assert_eq!(
-            fs::read_to_string(out.path()).unwrap(),
-            "5dcd612ee1fd3aa3\n"
         );
         assert!(!Path::new(&format!("{}.tmp", out.path())).exists());
     }


### PR DESCRIPTION
Mainnet fails loudly when `jito-stake-meta.json` is not produced (`--require-jito-stake-meta true`; testnet stays best-effort), and the upload is named `jito-stake-meta-<crc_tip>.<crc_priority>.json` so a Jito program redeploy makes the ETL fall back to Jito's bucket automatically. The hash is the POSIX `cksum` CRC of each program's `solana program dump` output — reproduce with `solana program dump <id> f.so && cksum f.so`; current value `2426260379.1775319386`.

Order-independent of marinade-finance/stakes-etl#86 (verified: nothing consumes the plain object name); the fast ETL path activates once both are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPCL5U99jygNNWAAknZHKQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional validation and generation of Jito stake metadata.
  * Jito metadata now includes a program hash for verification.
  * Added support for hash-qualified metadata filenames and output paths.
  * Added an option to require Jito metadata during snapshot processing.
  * Added validation for missing, duplicate, or incorrectly named metadata files.

* **Bug Fixes**
  * Snapshot processing now clearly fails when required Jito metadata is unavailable or invalid.
  * Testnet processing no longer requires priority-fee data or Jito stake metadata unless explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->