### PR TITLE
[GEN-8772] License the snapshot-parser workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+license = "Apache-2.0"
+
 
 [profile.release]
 codegen-units = 1

--- a/snapshot-parser-tokens-cli/Cargo.toml
+++ b/snapshot-parser-tokens-cli/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 name = "snapshot-parser-tokens-cli"
 version = "0.0.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ahash = { workspace = true }

--- a/snapshot-parser-validator-cli/Cargo.toml
+++ b/snapshot-parser-validator-cli/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 name = "snapshot-parser-validator-cli"
 version = "0.0.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ahash = { workspace = true }

--- a/snapshot-parser/Cargo.toml
+++ b/snapshot-parser/Cargo.toml
@@ -3,6 +3,7 @@ publish = false
 name = "snapshot-parser"
 version = "0.0.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ahash = { workspace = true }


### PR DESCRIPTION
Adds `license = "Apache-2.0"` to the three workspace crates, which already carry `publish = false`, so they stay licensed if `licenses.private.ignore` is ever retired.

No advisory work was needed: #50 already bumped the lockfile to `h2` 0.4.16, clearing RUSTSEC-2026-0258, so on current master cargo-deny 0.20.2 (`--all-features`) reports 1 error under the incoming org config and 1 under the config CI enforces today, and this change moves neither. Its measured effect is with `private.ignore = false`, where the same licenses check goes from 3 `unlicensed` errors to 0.

The one remaining error differs by config and neither is fixable here: the org config reports `bincode` 1.3.3 (RUSTSEC-2025-0141, `patched = []`, a direct dependency of `snapshot-parser` and `snapshot-parser-validator-cli`), while today's CI config reports `bitmaps` 3.2.1 (RUSTSEC-2026-0247, all versions affected, reached through `imbl` → `solana-runtime` 4.2.1).

`cargo metadata --locked` confirms no package requires rustc above the 1.94.1 pin (highest is 1.91).

⚠️ No effect on `validator-bonds`, which consumes these crates at tag `solana-2.3.x` — that tag predates `publish = false` on master and carries neither field, so clearing its findings needs a new tag plus a re-pin there.